### PR TITLE
[FIX][l10n_th_vat_report] Missing functions on_attach_callback and on_detach_callback in report_backend widget.

### DIFF
--- a/l10n_th_vat_report/static/src/js/l10n_th_vat_report_backend.js
+++ b/l10n_th_vat_report/static/src/js/l10n_th_vat_report_backend.js
@@ -102,6 +102,12 @@ odoo.define('l10n_th_vat_report.l10n_th_vat_report_backend', function (require) 
         canBeRemoved: function () {
             return $.when();
         },
+        on_attach_callback: function () {
+            this.isInDOM = true;
+        },
+        on_detach_callback: function () {
+            this.isInDOM = false;
+        },
     });
 
     core.action_registry.add(


### PR DESCRIPTION
These missing two function in the widget cause two bugs in the Odoo
Client. (tested on Odoo Enterprise Version).

1. The bug occor when we are on VAT Report view page then "click" on "Home
menu" (located on the top left of the screen). This bug is caused by
missing of on_detach_callback.

2. The bug occor when we are on VAT Report view page and then we
"refresh" the page (pressing F5 or CTRL+R). This bug is caused by
missing of on_attach_callback.

![DeepinScreenshot_select-area_20200116150726](https://user-images.githubusercontent.com/7752934/72508780-e5bfba80-3878-11ea-8898-8383f2f8767f.png)

![DeepinScreenshot_select-area_20200116152118](https://user-images.githubusercontent.com/7752934/72508813-f2dca980-3878-11ea-805f-3282f573f933.png)



