### PR TITLE
[FIX][l10n_th_withholding_tax_report] Missing functions on report_backend widget.

### DIFF
--- a/l10n_th_withholding_tax_report/static/src/js/withholding_tax_report_backend.js
+++ b/l10n_th_withholding_tax_report/static/src/js/withholding_tax_report_backend.js
@@ -104,6 +104,12 @@ odoo.define('l10n_th_withholding_tax_report.withholding_tax_report_backend', fun
         canBeRemoved: function () {
             return $.when();
         },
+        on_attach_callback: function () {
+            this.isInDOM = true;
+        },
+        on_detach_callback: function () {
+            this.isInDOM = false;
+        },
     });
 
     core.action_registry.add(


### PR DESCRIPTION
These missing two function in the widget cause two bugs in the Odoo
Client. (tested on Odoo Enterprise Version).

1. The bug occur when we are on Withholding Tax Report view page, then "click" on "Home
menu" (located on the top left of the screen). This bug is caused by
missing of on_detach_callback.

2. The bug occur when we are on Withholding Tax Report view page and then we
"refresh" the page (pressing F5 or CTRL+R). This bug is caused by
missing of on_attach_callback.

![DeepinScreenshot_select-area_20200116151033](https://user-images.githubusercontent.com/7752934/72509511-51565780-387a-11ea-8e2c-b8df96c58954.png)

![DeepinScreenshot_select-area_20200116151910](https://user-images.githubusercontent.com/7752934/72509558-6206cd80-387a-11ea-8c88-9dfca21652d9.png)

