### PR TITLE
[13.0][FIX] l10n_th_tax_report, error on install

### DIFF
--- a/l10n_th_tax_report/reports/tax_report.py
+++ b/l10n_th_tax_report/reports/tax_report.py
@@ -7,9 +7,12 @@ from odoo import api, fields, models
 class TaxReportView(models.TransientModel):
     _name = "tax.report.view"
     _description = "Tax Report View"
-    _inherit = "account.move.line"
     _order = "id"
 
+    name = fields.Char()
+    company_id = fields.Many2one("res.company")
+    account_id = fields.Many2one("account.account")
+    partner_id = fields.Many2one("res.partner")
     tax_base_amount = fields.Float()
     tax_amount = fields.Float()
     tax_date = fields.Char()

--- a/l10n_th_tax_report/wizard/tax_report_wizard.py
+++ b/l10n_th_tax_report/wizard/tax_report_wizard.py
@@ -60,8 +60,8 @@ class TaxReportWizard(models.TransientModel):
             "company_id": self.company_id.id,
             "tax_id": self.tax_id.id,
             "date_range_id": self.date_range_id.id,
-            "date_from": self.date_range_id.date_from,
-            "date_to": self.date_range_id.date_to,
+            "date_from": self.date_range_id.date_start,
+            "date_to": self.date_range_id.date_end,
         }
 
     def _export(self, report_type):


### PR DESCRIPTION
This module still depends on
- [ ] report_xlsx_helper https://github.com/OCA/reporting-engine/pull/361

Error on install,
```
  File "/home/odoo/src/odoo/odoo/fields.py", line 3151, in _setup_regular_full
    raise TypeError(msg % (self, field))
TypeError: Many2many fields tax.report.view.sale_line_ids and account.move.line.sale_line_ids use the same table and columns
```

Note: now I use oca_dependencies.txt to ttps://github.com/OCA/reporting-engine/pull/361
so, it can works now. But still, we need to merge this PR.