### PR TITLE
[13.0][ADD] l10n_th_partner : swap text fields for Individual case

### DIFF
--- a/l10n_th_partner/views/res_partner_view.xml
+++ b/l10n_th_partner/views/res_partner_view.xml
@@ -37,4 +37,14 @@
          </field>
      </record>
 
+    <record id="view_partner_form_firstname" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="partner_firstname.view_partner_form_firstname" />
+        <field name="arch" type="xml">
+            <field name="firstname" position="after">
+                <field name="lastname" position="move"/>
+            </field>
+        </field>
+    </record>
+
 </odoo>

--- a/l10n_th_partner/views/res_users_view.xml
+++ b/l10n_th_partner/views/res_users_view.xml
@@ -11,5 +11,13 @@
             </xpath>
         </field>
     </record>
-
+        <record id="view_partner_form_firstname" model="ir.ui.view">
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="partner_firstname.view_partner_form_firstname" />
+        <field name="arch" type="xml">
+            <field name="firstname" position="after">
+                <field name="lastname" position="move"/>
+            </field>
+        </field>
+    </record>
 </odoo>

--- a/l10n_th_partner/views/res_users_view.xml
+++ b/l10n_th_partner/views/res_users_view.xml
@@ -11,13 +11,4 @@
             </xpath>
         </field>
     </record>
-        <record id="view_partner_form_firstname" model="ir.ui.view">
-        <field name="model">res.partner</field>
-        <field name="inherit_id" ref="partner_firstname.view_partner_form_firstname" />
-        <field name="arch" type="xml">
-            <field name="firstname" position="after">
-                <field name="lastname" position="move"/>
-            </field>
-        </field>
-    </record>
 </odoo>


### PR DESCRIPTION
l10n_th_partner has a feature which separates an individual name to "First name" and "Last name". But the current input form for "Individual" starts with "Last name", then follow by "First name". Apparently, Thais will expect "First name" first. 

From my experience of this module first testing, I didn't notice the label "Last name", and I just typed the first name in that text field.

![image](https://user-images.githubusercontent.com/16228313/76333627-7a4c1380-6324-11ea-9e92-28ee8e8740ed.png)

This PR proposes swapping these text fields to the order of "first name" first, follow by "last name".

![image](https://user-images.githubusercontent.com/16228313/76333394-280af280-6324-11ea-99cf-46e803752120.png)
