### PR TITLE
[12.0][FIX] l10n_th_vendor_tax_invoice,

### DIFF
--- a/l10n_th_vendor_tax_invoice/models/account_move.py
+++ b/l10n_th_vendor_tax_invoice/models/account_move.py
@@ -142,13 +142,3 @@ class AccountPartialReconcile(models.Model):
         ctx = {'cash_basis_entry_move_line': move_line,
                'payment': payment}
         return self.with_context(ctx)
-
-    def create_tax_cash_basis_entry(self, percentage_before_rec):
-        """Only for Thai localization, delete unused account move lines."""
-        res = super(AccountPartialReconcile, self).create_tax_cash_basis_entry(
-            percentage_before_rec)
-        move_line = self.env['account.move.line'].search([
-            ('move_id.tax_cash_basis_rec_id', '=', self.id)]).filtered(
-            lambda l: not l.payment_tax_line_id)
-        move_line.unlink()
-        return res


### PR DESCRIPTION
Do not delete unused account move lines, it cause other error when
use with other addons.

And it don't need to be deleted in the first place.