### PR TITLE
[13.0][FIX] l10n_th_tax_invoice, err when make payment

### DIFF
--- a/l10n_th_tax_invoice/models/account_move.py
+++ b/l10n_th_tax_invoice/models/account_move.py
@@ -94,7 +94,7 @@ class AccountMoveLine(models.Model):
                     raise UserError(_("Invalid Tax Base/Amount"))
 
     def create(self, vals):
-        if self._context.get("payment_id"):
+        if vals and self._context.get("payment_id"):
             vals["payment_id"] = self._context["payment_id"]
         move_lines = super().create(vals)
         TaxInvoice = self.env["account.move.tax.invoice"]


### PR DESCRIPTION
File "/home/odoo/src/user/l10n_th_tax_invoice/models/account_move.py", line 98, in create
vals["payment_id"] = self._context["payment_id"]
TypeError: list indices must be integers or slices, not str