### PR TITLE
[FIX] Tax Report, use partner from tax invoice

### DIFF
--- a/l10n_th_tax_report/reports/tax_report.py
+++ b/l10n_th_tax_report/reports/tax_report.py
@@ -45,7 +45,7 @@ class TaxReport(models.TransientModel):
                 tax_invoice_number, tax_date, name,
                 sum(tax_base_amount) tax_base_amount, sum(tax_amount) tax_amount
             from (
-            select t.id, t.company_id, ml.account_id, ml.partner_id,
+            select t.id, t.company_id, ml.account_id, t.partner_id,
               case when ml.parent_state = 'posted' and t.reversing_id is null
                 then t.tax_invoice_number else
                 t.tax_invoice_number || ' (VOID)' end as tax_invoice_number,


### PR DESCRIPTION
From previous iteration, we did add partner_id into account_move_tax_invoice
but forget to fix also the tax report to use it instead of from account_move_line