### PR TITLE
[13.0][FIX] l10n_th_tax_invoice, unlink move_line when same partner only

### DIFF
--- a/l10n_th_tax_invoice/models/account_move.py
+++ b/l10n_th_tax_invoice/models/account_move.py
@@ -184,10 +184,14 @@ class AccountMove(models.Model):
         # Cleanup, delete lines with same account_id and sum(amount) == 0
         for move in self:
             accounts = move.line_ids.mapped("account_id")
+            partners = move.line_ids.mapped("partner_id")
             for account in accounts:
-                lines = move.line_ids.filtered(lambda l: l.account_id == account)
-                if sum(lines.mapped("balance")) == 0:
-                    lines.unlink()
+                for partner in partners:
+                    lines = move.line_ids.filtered(
+                        lambda l: l.account_id == account and l.partner_id == partner
+                    )
+                    if sum(lines.mapped("balance")) == 0:
+                        lines.unlink()
 
         res = super().post()
 


### PR DESCRIPTION
Currently, we delete move_lines if it use same account with net balance = 0. But it should be the case for same partner only too.