### PR TITLE
[FIX] l10n_th_withholding_tax, error on _compute_wt_tax_id method

### DIFF
--- a/l10n_th_withholding_tax/models/account_move.py
+++ b/l10n_th_withholding_tax/models/account_move.py
@@ -18,9 +18,11 @@ class AccountMoveLine(models.Model):
     def _compute_wt_tax_id(self):
         for rec in self:
             # From invoice, default from product
-            if rec.move_id.type in ("out_invoice", "out_refund"):
+            if rec.move_id.type in ("out_invoice", "out_refund", "in_receipt"):
                 rec.wt_tax_id = rec.product_id.wt_tax_id
-            elif rec.move_id.type in ("in_invoice", "in_refund"):
+            elif rec.move_id.type in ("in_invoice", "in_refund", "out_receipt"):
                 rec.wt_tax_id = rec.product_id.supplier_wt_tax_id
             elif rec.payment_id:
                 rec.wt_tax_id = rec.payment_id.wt_tax_id
+            else:
+                rec.wt_tax_id = False


### PR DESCRIPTION
For v13, in any compute method, we need to ensure that the computed field will be assigned, even a False one.