### PR TITLE
[13.0][ENH] l10n_th_withholding_tax_cert, use service action to call create cert

### DIFF
--- a/l10n_th_withholding_tax_cert/models/withholding_tax_cert.py
+++ b/l10n_th_withholding_tax_cert/models/withholding_tax_cert.py
@@ -263,6 +263,28 @@ class WithholdingTaxCert(models.Model):
         self.write({"state": "cancel"})
         return True
 
+    def _get_wth_cert_model_view(self):
+        res_model = "create.withholding.tax.cert"
+        view_id = self.env.ref(
+            "l10n_th_withholding_tax_cert.create_withholding_tax_cert"
+        ).id
+        return res_model, view_id
+
+    def action_create_withholding_tax_cert(self):
+        """ This function is called from either account.move or account.payment """
+        if not self._context.get("active_ids"):
+            return
+        res_model, view_id = self._get_wth_cert_model_view()
+        return {
+            "name": _("Create Withholding Tax Cert."),
+            "res_model": res_model,
+            "view_mode": "form",
+            "view_id": view_id,
+            "context": self.env.context,
+            "target": "new",
+            "type": "ir.actions.act_window",
+        }
+
 
 class WithholdingTaxCertLine(models.Model):
     _name = "withholding.tax.cert.line"

--- a/l10n_th_withholding_tax_cert/tests/test_wt_cert.py
+++ b/l10n_th_withholding_tax_cert/tests/test_wt_cert.py
@@ -31,7 +31,6 @@ class TestWTCert(SavepointCase):
         cls.account_move = cls.env["account.move"]
         cls.account_payment = cls.env["account.payment"]
         cls.wt_cert = cls.env["withholding.tax.cert"]
-        cls.wt_cert_wizard = cls.env["create.withholding.tax.cert"]
         cls.wt_account = cls.browse_ref(
             cls, "l10n_th_withholding_tax.withholding_income_tax_account"
         )
@@ -121,7 +120,8 @@ class TestWTCert(SavepointCase):
             "active_ids": [payment.id],
             "active_model": "account.payment",
         }
-        f = Form(self.wt_cert_wizard.with_context(ctx))
+        res = self.wt_cert.with_context(ctx).action_create_withholding_tax_cert()
+        f = Form(self.env[res["res_model"]].with_context(res["context"]))
         wizard = f.save()
         res = wizard.create_wt_cert()
         # New WT Cert
@@ -166,7 +166,8 @@ class TestWTCert(SavepointCase):
             "active_ids": [invoice_id.id],
             "active_model": "account.move",
         }
-        f = Form(self.wt_cert_wizard.with_context(ctx))
+        res = self.wt_cert.with_context(ctx).action_create_withholding_tax_cert()
+        f = Form(self.env[res["res_model"]].with_context(res["context"]))
         wizard = f.save()
         wizard.write({"wt_account_ids": invoice_id.line_ids.mapped("account_id")})
         res = wizard.create_wt_cert()

--- a/l10n_th_withholding_tax_cert/wizard/create_withholding_tax_cert.xml
+++ b/l10n_th_withholding_tax_cert/wizard/create_withholding_tax_cert.xml
@@ -45,25 +45,30 @@
             </form>
         </field>
     </record>
-    <record id="action_create_withholding_tax_cert" model="ir.actions.act_window">
+    <record id="action_create_withholding_tax_cert" model="ir.actions.server">
         <field name="name">Create Withholding Tax Cert.</field>
-        <field name="type">ir.actions.act_window</field>
-        <field name="res_model">create.withholding.tax.cert</field>
-        <field name="view_mode">form</field>
-        <field name="view_id" ref="create_withholding_tax_cert" />
-        <field name="context">{}</field>
-        <field name="target">new</field>
+        <field
+            name="model_id"
+            ref="l10n_th_withholding_tax_cert.model_create_withholding_tax_cert"
+        />
         <field name="binding_model_id" ref="account.model_account_payment" />
+        <field name="binding_view_types">list,form</field>
+        <field name="state">code</field>
+        <field name="code">
+            action = env['withholding.tax.cert'].action_create_withholding_tax_cert()
+        </field>
     </record>
-    <record id="action_move_create_withholding_tax_cert" model="ir.actions.act_window">
+    <record id="action_move_create_withholding_tax_cert" model="ir.actions.server">
         <field name="name">Create Withholding Tax Cert.</field>
-        <field name="type">ir.actions.act_window</field>
-        <field name="res_model">create.withholding.tax.cert</field>
-        <field name="view_mode">form</field>
-        <field name="view_id" ref="create_withholding_tax_cert" />
-        <field name="context">{}</field>
-        <field name="target">new</field>
+        <field
+            name="model_id"
+            ref="l10n_th_withholding_tax_cert.model_create_withholding_tax_cert"
+        />
         <field name="binding_model_id" ref="account.model_account_move" />
-        <field name="binding_view_types">form</field>
+        <field name="binding_view_types">list,form</field>
+        <field name="state">code</field>
+        <field name="code">
+            action = env['withholding.tax.cert'].action_create_withholding_tax_cert()
+        </field>
     </record>
 </odoo>


### PR DESCRIPTION
This module use server action to call wizard create cert.
The action will call function `action_create_withholding_tax_cert`, and so it will be more flexible to change wizard.

No feature add, just prepare HOOK for module l10n_th_withholding_tax_cert_multi.