### PR TITLE
[13.0][FIX] l10n_th_withholding_tax_cert_form : domain groupby wt_lines

### DIFF
--- a/l10n_th_withholding_tax_cert_form/models/withholding_tax_cert.py
+++ b/l10n_th_withholding_tax_cert_form/models/withholding_tax_cert.py
@@ -16,8 +16,8 @@ class WithholdingTaxCert(models.Model):
         return desc
 
     def _group_wt_line(self, lines):
-        groups = lines.read_group(
-            domain=[],
+        groups = self.env["withholding.tax.cert.line"].read_group(
+            domain=[("id", "in", lines.ids)],
             fields=["wt_cert_income_type", "base", "amount"],
             groupby=["wt_cert_income_type"],
             lazy=False,


### PR DESCRIPTION
Error print cert if document > 1, it will print all document into 1 form

![Selection_001](https://user-images.githubusercontent.com/20896369/99211196-61242c80-27fa-11eb-8578-aed846495285.png)
![Selection_002](https://user-images.githubusercontent.com/20896369/99211199-62555980-27fa-11eb-952a-aee07cd5612d.png)
