### PR TITLE
[13.0][IMP] l10n_th_tax_invoice, Allow move reset draft

### DIFF
--- a/l10n_th_tax_invoice/models/account_move.py
+++ b/l10n_th_tax_invoice/models/account_move.py
@@ -133,8 +133,6 @@ class AccountMoveLine(models.Model):
                     raise UserError(_("Invalid Tax Amount"))
 
     def create(self, vals):
-        if vals and self._context.get("payment_id"):
-            vals["payment_id"] = self._context["payment_id"]
         move_lines = super().create(vals)
         TaxInvoice = self.env["account.move.tax.invoice"]
         sign = self._context.get("reverse_tax_invoice") and -1 or 1
@@ -307,18 +305,6 @@ class AccountMove(models.Model):
         return super()._reverse_moves(
             default_values_list=default_values_list, cancel=cancel
         )
-
-    def button_draft(self):
-        # Do not set draft cash basis move tax invoice created from payment
-        # They are move "entry" with tax invoice line and are not manual tax
-        moves = self.filtered(
-            lambda m: not (
-                m.type == "entry"
-                and m.tax_invoice_ids
-                and not m.line_ids.filtered("manual_tax_invoice")
-            )
-        )
-        return super(AccountMove, moves).button_draft()
 
     def unlink(self):
         # Do not unlink cash basis move on payment, they will be reversed

--- a/l10n_th_tax_invoice/tests/test_tax_invoice.py
+++ b/l10n_th_tax_invoice/tests/test_tax_invoice.py
@@ -276,7 +276,8 @@ class TestTaxInvoice(SingleTransactionCase):
         # Cash basis journal is now posted
         self.assertEquals(payment.tax_invoice_ids.mapped("move_id").state, "posted")
         # Check the move_line_ids, from both Bank and Cash Basis journal
-        self.assertEquals(len(payment.move_line_ids.mapped("move_id")), 2)
+        self.assertTrue(payment.move_id)
+        self.assertTrue(payment.tax_invoice_move_id)
         payment.action_draft()  # Unlink the relation
         self.assertFalse(payment.move_line_ids)
 
@@ -316,7 +317,8 @@ class TestTaxInvoice(SingleTransactionCase):
         tax_invoice_number = tax_invoices.mapped("tax_invoice_number")[0]
         self.assertEqual(tax_invoice_number, "Cust Receipt")
         # Check the move_line_ids, from both Bank and Cash Basis journal
-        self.assertEquals(len(payment.move_line_ids.mapped("move_id")), 2)
+        self.assertTrue(payment.move_id)
+        self.assertTrue(payment.tax_invoice_move_id)
         payment.action_draft()  # Unlink the relation
         self.assertFalse(payment.move_line_ids)
 
@@ -365,7 +367,8 @@ class TestTaxInvoice(SingleTransactionCase):
         tax_invoice_number = tax_invoices.mapped("tax_invoice_number")[0]
         self.assertEqual(tax_invoice_number, "CTX0002")
         # Check the move_line_ids, from both Bank and Cash Basis journal
-        self.assertEquals(len(payment.move_line_ids.mapped("move_id")), 2)
+        self.assertTrue(payment.move_id)
+        self.assertTrue(payment.tax_invoice_move_id)
         payment.action_draft()  # Unlink the relation
         self.assertFalse(payment.move_line_ids)
 

--- a/l10n_th_tax_invoice/views/account_payment_view.xml
+++ b/l10n_th_tax_invoice/views/account_payment_view.xml
@@ -17,6 +17,16 @@
                     attrs="{'invisible': ['|', ('to_clear_tax', '=', False), ('state', '!=', 'posted')]}"
                 />
             </button>
+            <field name="payment_method_id" position="after">
+                <field
+                    name="move_id"
+                    attrs="{'invisible': [('move_id', '=', False)]}"
+                />
+                <field
+                    name="tax_invoice_move_id"
+                    attrs="{'invisible': [('tax_invoice_move_id', '=', False)]}"
+                />
+            </field>
             <group position="after">
                 <notebook attrs="{'invisible': [('tax_invoice_ids', '=', [])]}">
                     <page string="Tax Invoice" name="tax_invoice">


### PR DESCRIPTION
Previous to this fix, the system will stamp "payment_id" into account.move.line of Cash Basis Entry (to allow linking from payment to all related move_ids). This in a way, break Odoo standard (normally, cash basis entry do not link to payment). This thing also make it not possible to set to draft in some situation.

We change a bit, by adding 2 new computed fields, without breaking anything Odoo. And then, remove the code that prevent from JE set to draft in some scenario.
![image](https://user-images.githubusercontent.com/1973598/100198306-3e96bf80-2f2e-11eb-8bd9-39a50a513c53.png)


