### PR TITLE
[13.0][IMP] l10n_th_tax_invoice, for JE of tax cash basis, no line recalc

### DIFF
--- a/l10n_th_tax_invoice/models/account_move.py
+++ b/l10n_th_tax_invoice/models/account_move.py
@@ -194,6 +194,13 @@ class AccountMove(models.Model):
         copy=False,
     )
 
+    @api.onchange("date", "currency_id")
+    def _onchange_currency(self):
+        """ For tax cash basis entry, do not recalc lines """
+        if self.tax_cash_basis_rec_id:
+            return
+        super()._onchange_currency()
+
     def post(self):
         """ Additional tax invoice info (tax_invoice_number, tax_invoice_date)
             Case sales tax, use Odoo's info, as document is issued out.


### PR DESCRIPTION
This ensure that, for cash basis entry (payment due tax), user can still change date without affecting lines.