### PR TITLE
[13.0][FIX] l10n_th_base_location : To remove "(TH)" at the end of state name for Thai addresses

### DIFF
--- a/l10n_th_base_location/models/__init__.py
+++ b/l10n_th_base_location/models/__init__.py
@@ -3,3 +3,4 @@
 from . import res_partner
 from . import res_company
 from . import res_city_zip
+from . import res_country_state

--- a/l10n_th_base_location/models/res_country_state.py
+++ b/l10n_th_base_location/models/res_country_state.py
@@ -3,7 +3,7 @@
 from odoo import models
 
 class CountryState(models.Model):
-    _inherit = 'res.country.state'
+    _inherit = "res.country.state"
 
     def name_get(self):
         result = []
@@ -11,5 +11,7 @@ class CountryState(models.Model):
             if record.country_id.code == "TH":
                 result.append((record.id, record.name))
             else:
-                result.append((record.id, "{} ({})".format(record.name, record.country_id.code)))
+                result.append(
+                    (record.id, "{} ({})".format(record.name, record.country_id.code))
+                )
         return result

--- a/l10n_th_base_location/models/res_country_state.py
+++ b/l10n_th_base_location/models/res_country_state.py
@@ -13,7 +13,5 @@ class CountryState(models.Model):
             if record.country_id.code == "TH":
                 result.append((record.id, record.name))
             else:
-                result.append(
-                    (record.id, "{} ({})".format(record.name, record.country_id.code))
-                )
+                result.append(super(CountryState, record).name_get()[0])
         return result

--- a/l10n_th_base_location/models/res_country_state.py
+++ b/l10n_th_base_location/models/res_country_state.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models
+
+class CountryState(models.Model):
+    _inherit = 'res.country.state'
+
+    def name_get(self):
+        result = []
+        for record in self:
+            if record.country_id.code == "TH":
+                result.append((record.id, record.name))
+            else:
+                result.append((record.id, "{} ({})".format(record.name, record.country_id.code)))
+        return result

--- a/l10n_th_base_location/models/res_country_state.py
+++ b/l10n_th_base_location/models/res_country_state.py
@@ -1,6 +1,8 @@
-# -*- coding: utf-8 -*-
+# Copyright 2021 Sansiri Tanachutiwat
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
 from odoo import models
+
 
 class CountryState(models.Model):
     _inherit = "res.country.state"

--- a/l10n_th_base_location/tests/test_base_location.py
+++ b/l10n_th_base_location/tests/test_base_location.py
@@ -84,7 +84,7 @@ class TestBaseLocation(TransactionCase):
         company._onchange_zip_id()
         self.assertEqual(company.street2, address[0])
         self.assertEqual(company.city, address[1])
-        
+
     def test_04_th_address(self):
         """Test name_get() for Thai address"""
         state_id = self.env["res.country.state"].search([("name", "like", "กรุงเทพ")])

--- a/l10n_th_base_location/tests/test_base_location.py
+++ b/l10n_th_base_location/tests/test_base_location.py
@@ -87,26 +87,30 @@ class TestBaseLocation(TransactionCase):
         
     def test_04_th_address(self):
         """Test name_get() for Thai address"""
-        state_id = self.env['res.country.state'].search([('name', 'like', 'กรุงเทพ')])
-        record = self.env['res.partner'].create({
-            'name': 'ทำเนียบรัฐบาล',
-            'street': '1 ถนนนครปฐม',
-            'street2': 'แขวงถนนนครไชยศรี',
-            'city': 'เขตดุสิต',
-            'state_id': state_id.id,
-        })
+        state_id = self.env["res.country.state"].search([("name", "like", "กรุงเทพ")])
+        record = self.env["res.partner"].create(
+            {
+                "name": "ทำเนียบรัฐบาล",
+                "street": "1 ถนนนครปฐม",
+                "street2": "แขวงถนนนครไชยศรี",
+                "city": "เขตดุสิต",
+                "state_id": state_id.id,
+            }
+        )
         name = record.state_id.name_get()
-        self.assertNotEqual(name[0][1][-4:], '(TH)')
+        self.assertNotEqual(name[0][1][-4:], "(TH)")
 
     def test_05_us_address(self):
         """Test name_get() for USA address"""
-        state_id = self.env['res.country.state'].search([('code', '=', 'NY')])
-        record = self.env['res.partner'].create({
-            'name': 'United Nations Headquarters',
-            'street': '405 East 42nd Street',
-            'street2': '',
-            'city': 'New York',
-            'state_id': state_id.id,
-        })
+        state_id = self.env["res.country.state"].search([("code", "=", "NY")])
+        record = self.env["res.partner"].create(
+            {
+                "name": "United Nations Headquarters",
+                "street": "405 East 42nd Street",
+                "street2": "",
+                "city": "New York",
+                "state_id": state_id.id,
+            }
+        )
         name = record.state_id.name_get()
-        self.assertEqual(name[0][1][-4:], '(US)')
+        self.assertEqual(name[0][1][-4:], "(US)")

--- a/l10n_th_base_location/tests/test_base_location.py
+++ b/l10n_th_base_location/tests/test_base_location.py
@@ -84,3 +84,29 @@ class TestBaseLocation(TransactionCase):
         company._onchange_zip_id()
         self.assertEqual(company.street2, address[0])
         self.assertEqual(company.city, address[1])
+        
+    def test_04_th_address(self):
+        """Test name_get() for Thai address"""
+        state_id = self.env['res.country.state'].search([('name', 'like', 'กรุงเทพ')])
+        record = self.env['res.partner'].create({
+            'name': 'ทำเนียบรัฐบาล',
+            'street': '1 ถนนนครปฐม',
+            'street2': 'แขวงถนนนครไชยศรี',
+            'city': 'เขตดุสิต',
+            'state_id': state_id.id,
+        })
+        name = record.state_id.name_get()
+        self.assertNotEqual(name[0][1][-4:], '(TH)')
+
+    def test_05_us_address(self):
+        """Test name_get() for USA address"""
+        state_id = self.env['res.country.state'].search([('code', '=', 'NY')])
+        record = self.env['res.partner'].create({
+            'name': 'United Nations Headquarters',
+            'street': '405 East 42nd Street',
+            'street2': '',
+            'city': 'New York',
+            'state_id': state_id.id,
+        })
+        name = record.state_id.name_get()
+        self.assertEqual(name[0][1][-4:], '(US)')


### PR DESCRIPTION
This is solely to remove "(TH)" at the end of state name.
เพื่อลบ "(TH)" ออกจากท้ายชื่อจังหวัด สำหรับที่อยู่ในประเทศไทย