### PR TITLE
[IMP] l10n_th_withholding_tax: register a payment with multi invoices

### DIFF
--- a/l10n_th_withholding_tax/README.rst
+++ b/l10n_th_withholding_tax/README.rst
@@ -45,7 +45,9 @@ From bills / invoices that require withheld tax,
 **Note**
 
 - if you configured withholding tax on product, it fill withholding tax in field WT automatic.
-- you can't register a payment with multi invoices, when there is withholding tax in line.
+- for invoices with withholding tax,
+    - you can't make payment to multiple invoices belongs to multiple partners.
+    - you can only make payment to multiple invoices belongs to the same partner (using Group Payments).
 
 Bug Tracker
 ===========
@@ -68,8 +70,11 @@ Authors
 Contributors
 ~~~~~~~~~~~~
 
-* Kitti Upariphutthiphong. <kittiu@gmail.com> (http://ecosoft.co.th)
-* Saran Lim. <saranl@ecosoft.co.th>
+* `Ecosoft <http://ecosoft.co.th>`__:
+
+  * Kitti U. <kittiu@ecosoft.co.th>
+  * Saran Lim. <saranl@ecosoft.co.th>
+  * Pimolnat Suntian <pimolnats@ecosoft.co.th>
 
 Maintainers
 ~~~~~~~~~~~

--- a/l10n_th_withholding_tax/readme/CONTRIBUTORS.rst
+++ b/l10n_th_withholding_tax/readme/CONTRIBUTORS.rst
@@ -1,2 +1,5 @@
-* Kitti Upariphutthiphong. <kittiu@gmail.com> (http://ecosoft.co.th)
-* Saran Lim. <saranl@ecosoft.co.th>
+* `Ecosoft <http://ecosoft.co.th>`__:
+
+  * Kitti U. <kittiu@ecosoft.co.th>
+  * Saran Lim. <saranl@ecosoft.co.th>
+  * Pimolnat Suntian <pimolnats@ecosoft.co.th>

--- a/l10n_th_withholding_tax/readme/USAGE.rst
+++ b/l10n_th_withholding_tax/readme/USAGE.rst
@@ -7,4 +7,6 @@ From bills / invoices that require withheld tax,
 **Note**
 
 - if you configured withholding tax on product, it fill withholding tax in field WT automatic.
-- you can't register a payment with multi invoices, when there is withholding tax in line.
+- for invoices with withholding tax,
+    - you can't make payment to multiple invoices belongs to multiple partners.
+    - you can only make payment to multiple invoices belongs to the same partner (using Group Payments).

--- a/l10n_th_withholding_tax/static/description/index.html
+++ b/l10n_th_withholding_tax/static/description/index.html
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-<meta name="generator" content="Docutils 0.15.1: http://docutils.sourceforge.net/" />
+<meta name="generator" content="Docutils: http://docutils.sourceforge.net/" />
 <title>Thai Localization - Withholding Tax</title>
 <style type="text/css">
 
@@ -394,7 +394,15 @@ compute amount include withholding tax automatic.</p>
 <p><strong>Note</strong></p>
 <ul class="simple">
 <li>if you configured withholding tax on product, it fill withholding tax in field WT automatic.</li>
-<li>you can’t register a payment with multi invoices, when there is withholding tax in line.</li>
+<li><dl class="first docutils">
+<dt>for invoices with withholding tax,</dt>
+<dd><ul class="first last">
+<li>you can’t make payment to multiple invoices belongs to multiple partners.</li>
+<li>you can only make payment to multiple invoices belongs to the same partner (using Group Payments).</li>
+</ul>
+</dd>
+</dl>
+</li>
 </ul>
 </div>
 <div class="section" id="bug-tracker">
@@ -416,8 +424,12 @@ If you spotted it first, help us smashing it by providing a detailed and welcome
 <div class="section" id="contributors">
 <h2><a class="toc-backref" href="#id5">Contributors</a></h2>
 <ul class="simple">
-<li>Kitti Upariphutthiphong. &lt;<a class="reference external" href="mailto:kittiu&#64;gmail.com">kittiu&#64;gmail.com</a>&gt; (<a class="reference external" href="http://ecosoft.co.th">http://ecosoft.co.th</a>)</li>
+<li><a class="reference external" href="http://ecosoft.co.th">Ecosoft</a>:<ul>
+<li>Kitti U. &lt;<a class="reference external" href="mailto:kittiu&#64;ecosoft.co.th">kittiu&#64;ecosoft.co.th</a>&gt;</li>
 <li>Saran Lim. &lt;<a class="reference external" href="mailto:saranl&#64;ecosoft.co.th">saranl&#64;ecosoft.co.th</a>&gt;</li>
+<li>Pimolnat Suntian &lt;<a class="reference external" href="mailto:pimolnats&#64;ecosoft.co.th">pimolnats&#64;ecosoft.co.th</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">


### PR DESCRIPTION
Allow registering a payment with multi invoices, when there is withholding tax in line.

But there are conditions as follows:
- 1 Partner: 1 Payment
- Use **Group Payments**

Because standard odoo auto post journal entry when registering a payment. Therefore, you can't edit the amount before posted in case of the amount from odoo is not equal to the amount from partner.