### PR TITLE
[14.0][ENH] l10n_th_partner: configure title and name space/no space

### DIFF
--- a/l10n_th_partner/__manifest__.py
+++ b/l10n_th_partner/__manifest__.py
@@ -13,6 +13,7 @@
         "data/res.partner.company.type.csv",
         "data/res.partner.title.csv",
         "views/res_company_view.xml",
+        "views/res_config_settings_views.xml",
         "views/res_partner_company_type_view.xml",
         "views/res_partner_view.xml",
         "views/res_users_view.xml",

--- a/l10n_th_partner/models/__init__.py
+++ b/l10n_th_partner/models/__init__.py
@@ -1,6 +1,8 @@
 # Copyright 2019 Ecosoft Co., Ltd (http://ecosoft.co.th/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
 from . import res_company
+from . import res_config_settings
 from . import res_partner_company_type
 from . import res_partner
 from . import res_users

--- a/l10n_th_partner/models/res_company.py
+++ b/l10n_th_partner/models/res_company.py
@@ -9,3 +9,7 @@ class ResCompany(models.Model):
     branch = fields.Char(
         related="partner_id.branch", string="Tax Branch", readonly=False
     )
+    no_space_title_name = fields.Boolean(
+        string="No Space Title and Name",
+        help="If checked, title and name will no space",
+    )

--- a/l10n_th_partner/models/res_company.py
+++ b/l10n_th_partner/models/res_company.py
@@ -13,3 +13,14 @@ class ResCompany(models.Model):
         string="No Space Title and Name",
         help="If checked, title and name will no space",
     )
+
+    def write(self, vals):
+        """ Automation update name when you config no_space_title_name """
+        res = super().write(vals)
+        if "no_space_title_name" in vals:
+            personal_partners = self.env["res.partner"].search([("title", "!=", False)])
+            for partner in personal_partners:
+                partner.name = partner._get_computed_name(
+                    partner.lastname, partner.firstname
+                )
+        return res

--- a/l10n_th_partner/models/res_config_settings.py
+++ b/l10n_th_partner/models/res_config_settings.py
@@ -1,0 +1,11 @@
+# Copyright 2020 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    no_space_title_name = fields.Boolean(
+        related="company_id.no_space_title_name", readonly=False
+    )

--- a/l10n_th_partner/models/res_partner.py
+++ b/l10n_th_partner/models/res_partner.py
@@ -36,6 +36,9 @@ class ResPartner(models.Model):
         name = super()._get_computed_name(lastname, firstname)
         title = self.title.name
         if name and title:
+            # disable space on title and name
+            if self.env.company.no_space_title_name:
+                return "".join(p for p in (title, name) if p)
             return " ".join(p for p in (title, name) if p)
         return name
 

--- a/l10n_th_partner/tests/test_l10n_th_partner.py
+++ b/l10n_th_partner/tests/test_l10n_th_partner.py
@@ -7,6 +7,7 @@ from odoo.tests.common import TransactionCase
 class TestL10nThPartner(TransactionCase):
     def setUp(self):
         super(TestL10nThPartner, self).setUp()
+        self.main_company = self.env.ref("base.main_company")
         self.create_title()
         self.create_original("Firstname", "Lastname")
 
@@ -36,3 +37,11 @@ class TestL10nThPartner(TransactionCase):
         partner.company_type = "company"
         partner._onchange_company_type()
         self.assertNotEqual(partner.title, self.title)
+
+    def test_res_users_config_no_space(self):
+        """Test that you change title and config title no space"""
+        self.assertEqual(self.user.name, "Firstname Lastname")
+        self.user.title = self.title
+        self.main_company.no_space_title_name = True
+        self.user._compute_name()
+        self.assertEqual(self.user.name, "MissFirstname Lastname")

--- a/l10n_th_partner/tests/test_l10n_th_partner.py
+++ b/l10n_th_partner/tests/test_l10n_th_partner.py
@@ -40,8 +40,7 @@ class TestL10nThPartner(TransactionCase):
 
     def test_res_users_config_no_space(self):
         """Test that you change title and config title no space"""
+        self.main_company.no_space_title_name = True
         self.assertEqual(self.user.name, "Firstname Lastname")
         self.user.title = self.title
-        self.main_company.no_space_title_name = True
-        self.user._compute_name()
         self.assertEqual(self.user.name, "MissFirstname Lastname")

--- a/l10n_th_partner/views/res_config_settings_views.xml
+++ b/l10n_th_partner/views/res_config_settings_views.xml
@@ -18,7 +18,7 @@
                     <div class="o_setting_right_pane">
                         <label for="no_space_title_name" />
                         <div class="text-muted">
-                            Disable space between title and name. example:
+                            Disable space between title and name. example:<br />
                             Miss Firstname Lastname -> MissFirstname Lastname
                         </div>
                     </div>

--- a/l10n_th_partner/views/res_config_settings_views.xml
+++ b/l10n_th_partner/views/res_config_settings_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- Copyright 2022 Ecosoft
+     License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html). -->
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form</field>
+        <field name="model">res.config.settings</field>
+        <field
+            name="inherit_id"
+            ref="partner_firstname.res_config_settings_view_form"
+        />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@name='partner_names_order']" position="inside">
+                <div class="col-xs-12 col-md-6 o_setting_box">
+                    <div class="o_setting_left_pane">
+                        <field name="no_space_title_name" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="no_space_title_name" />
+                        <div class="text-muted">
+                            Disable space between title and name. example:
+                            Miss Firstname Lastname -> MissFirstname Lastname
+                        </div>
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Enhance:
- Configure display name space or no space title-name
![Selection_001](https://user-images.githubusercontent.com/20896369/153557982-342bff3d-35de-4688-a79e-835cd41a2615.png)

you can configuration that space or no space title name.
![Selection_002](https://user-images.githubusercontent.com/20896369/153558093-e496b834-f126-4e56-93b3-fc6cd938d7da.png)

