### PR TITLE
[NOTMERGE][14.0] l10n_th_partner: partner title with standard

### DIFF
--- a/l10n_th_partner/__init__.py
+++ b/l10n_th_partner/__init__.py
@@ -1,4 +1,3 @@
-# Copyright 2019 Ecosoft Co., Ltd (http://ecosoft.co.th/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
 from . import models
-from .hooks import post_init_hook

--- a/l10n_th_partner/__manifest__.py
+++ b/l10n_th_partner/__manifest__.py
@@ -3,7 +3,7 @@
 
 {
     "name": "Thai Localization - Partner",
-    "version": "14.0.2.1.0",
+    "version": "14.0.2.2.0",
     "author": "Ecosoft, Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/l10n-thailand",
     "license": "AGPL-3",
@@ -18,7 +18,6 @@
         "views/res_partner_view.xml",
         "views/res_users_view.xml",
     ],
-    "post_init_hook": "post_init_hook",
     "installable": True,
     "development_status": "Beta",
     "maintainers": ["kittiu"],

--- a/l10n_th_partner/hooks.py
+++ b/l10n_th_partner/hooks.py
@@ -1,9 +1,0 @@
-# Copyright 2020 Ecosoft Co., Ltd (http://ecosoft.co.th/)
-# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
-from odoo import SUPERUSER_ID, api
-
-
-def post_init_hook(cr, _):
-    with api.Environment.manage():
-        env = api.Environment(cr, SUPERUSER_ID, {})
-        env["res.partner"]._install_l10n_th_partner()

--- a/l10n_th_partner/migrations/14.0.2.2.0/post-migration.py
+++ b/l10n_th_partner/migrations/14.0.2.2.0/post-migration.py
@@ -1,0 +1,25 @@
+# Copyright 2021 Ecosoft Co., Ltd (http://ecosoft.co.th/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+import logging
+
+from odoo import SUPERUSER_ID, api
+
+_logger = logging.getLogger(__name__)
+
+
+def _auto_update_field_display_fullname(cr, env):
+    _logger.info(
+        "Add value 'display_fullname' to 'res_partner' on upgrade to 14.0.2.2.0"
+    )
+    cr.execute(
+        "ALTER TABLE res_partner ADD COLUMN IF NOT EXISTS display_fullname VARCHAR"
+    )
+    all_partner = env["res.partner"].search([])
+    all_partner._compute_display_fullname()
+    _logger.info("====== Done: Compute display fullname ======")
+
+
+def migrate(cr, version):
+    with api.Environment.manage():
+        env = api.Environment(cr, SUPERUSER_ID, {})
+        _auto_update_field_display_fullname(cr, env)

--- a/l10n_th_partner/models/__init__.py
+++ b/l10n_th_partner/models/__init__.py
@@ -5,6 +5,7 @@ from . import res_company
 from . import res_config_settings
 from . import res_partner_company_type
 from . import res_partner
+from . import res_users
 from . import resource
 from . import ir_translation
 from . import hr_employee

--- a/l10n_th_partner/models/ir_translation.py
+++ b/l10n_th_partner/models/ir_translation.py
@@ -12,7 +12,6 @@ class IrTranslation(models.Model):
 
         # Recompute name for res.partner
         recompute_fields = [
-            "res.partner,name_company",
             "res.partner,firstname",
             "res.partner,lastname",
         ]

--- a/l10n_th_partner/models/res_company.py
+++ b/l10n_th_partner/models/res_company.py
@@ -19,8 +19,5 @@ class ResCompany(models.Model):
         res = super().write(vals)
         if "no_space_title_name" in vals:
             personal_partners = self.env["res.partner"].search([("title", "!=", False)])
-            for partner in personal_partners:
-                partner.name = partner._get_computed_name(
-                    partner.lastname, partner.firstname
-                )
+            personal_partners._compute_display_fullname()
         return res

--- a/l10n_th_partner/models/res_users.py
+++ b/l10n_th_partner/models/res_users.py
@@ -1,0 +1,22 @@
+# Copyright 2022 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import api, models
+
+
+class ResUsers(models.Model):
+    _inherit = "res.users"
+
+    def name_get(self):
+        """Overwrite name_get for display with title"""
+        res = [(rec.id, rec.display_fullname) for rec in self]
+        return res
+
+    @api.model
+    def name_search(self, name, args=None, operator="ilike", limit=100):
+        """Overwrite name_search for search with title"""
+        args = args or []
+        domain = []
+        if name:
+            domain = [("display_fullname", operator, name)]
+        return self.search(domain + args, limit=limit).name_get()

--- a/l10n_th_partner/tests/test_l10n_th_partner.py
+++ b/l10n_th_partner/tests/test_l10n_th_partner.py
@@ -23,26 +23,33 @@ class TestL10nThPartner(TransactionCase):
             f.login = firstname
         self.user = f.save()
 
-    def test_res_users(self):
-        """Test that you change title"""
-        self.assertEqual(self.user.name, "Firstname Lastname")
-        self.user.title = self.title
-        self.user._compute_name()
-        self.assertEqual(self.user.name, "Miss Firstname Lastname")
-
-    def test_res_partner(self):
+    def test_partner_company(self):
         """Test that you change company_type"""
         partner = self.user.partner_id
         partner.email = "test"
         partner.title = self.title
+        self.assertEqual(partner.name, "Firstname Lastname")
+        self.assertEqual(partner.display_fullname, "Miss Firstname Lastname")
         self.assertEqual(partner.title, self.title)
         partner.company_type = "company"
         partner._onchange_company_type()
         self.assertNotEqual(partner.title, self.title)
+        # title on display fullname will remove
+        self.assertEqual(partner.name, "Firstname Lastname")
+        self.assertEqual(partner.display_fullname, "Firstname Lastname")
 
-    def test_res_users_config_no_space(self):
-        """Test that you change title and config title no space"""
+    def test_user_individual(self):
+        """Test add title in individual"""
+        # Standard Odoo
+        self.assertEqual(self.user.name, "Firstname Lastname")
+        self.assertEqual(self.user.display_name, "Firstname Lastname")
+        self.user.title = self.title
+        self.assertEqual(self.user.name, "Firstname Lastname")
+        self.assertEqual(self.user.display_fullname, "Miss Firstname Lastname")
+        # Config no space title
         self.main_company.no_space_title_name = True
         self.assertEqual(self.user.name, "Firstname Lastname")
+        self.assertEqual(self.user.display_name, "Firstname Lastname")
         self.user.title = self.title
-        self.assertEqual(self.user.name, "MissFirstname Lastname")
+        self.assertEqual(self.user.name, "Firstname Lastname")
+        self.assertEqual(self.user.display_fullname, "MissFirstname Lastname")

--- a/l10n_th_partner/views/res_partner_view.xml
+++ b/l10n_th_partner/views/res_partner_view.xml
@@ -1,5 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
+    <record id="res_partner_kanban_view" model="ir.ui.view">
+        <field name="name">res.partner.kanban</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.res_partner_kanban_view" />
+        <field name="arch" type="xml">
+            <xpath expr="//templates//field[@name='display_name']" position="after">
+                <field name="display_fullname" />
+            </xpath>
+            <xpath
+                expr="//templates//field[@name='display_name']"
+                position="attributes"
+            >
+                <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_partner_tree" model="ir.ui.view">
+        <field name="name">res.partner.tree</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='display_name']" position="after">
+                <field name="display_fullname" />
+            </xpath>
+            <xpath expr="//field[@name='display_name']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
     <record id="view_partner_form" model="ir.ui.view">
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form" />
@@ -8,16 +38,13 @@
                 <field name="branch" placeholder="Branch, e.g., 00000" />
             </field>
             <xpath expr="//field[@name='name']" position="attributes">
-                <attribute name="readonly">1</attribute>
+                <attribute name="attrs">{
+                    'required' : [('type', '=', 'contact')],
+                    'invisible': [('company_type', '!=', 'company')]
+                }</attribute>
             </xpath>
-            <xpath expr="//h1//field[@name='name']/.." position="after">
-                <div class="oe_edit_only">
-                    <field
-                        name="name_company"
-                        placeholder="Company name"
-                        attrs="{'invisible': [('is_company', '=', False)], 'required': [('is_company', '=', True)]}"
-                    />
-                </div>
+            <xpath expr="//field[@name='name']" position="before">
+                <field name="display_fullname" /><br />
             </xpath>
         </field>
     </record>

--- a/l10n_th_partner/views/res_users_view.xml
+++ b/l10n_th_partner/views/res_users_view.xml
@@ -1,16 +1,62 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <odoo>
+    <record id="view_users_tree" model="ir.ui.view">
+        <field name="name">res.users.tree</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//tree/field[@name='name']" position="before">
+                <field name="display_fullname" />
+            </xpath>
+            <xpath expr="//tree/field[@name='name']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="view_users_form" model="ir.ui.view">
         <field name="name">Add title</field>
         <field name="model">res.users</field>
         <field name="inherit_id" ref="partner_firstname.view_users_form" />
         <field name="arch" type="xml">
             <xpath expr="//field[@name='name']" position="attributes">
-                <attribute name="force_save">True</attribute>
+                <attribute name="force_save">1</attribute>
+                <attribute name="invisible">1</attribute>
+            </xpath>
+            <xpath expr="//field[@name='name']" position="before">
+                <field name="display_fullname" /><br />
             </xpath>
             <xpath expr="//field[@name='lastname']" position="before">
                 <field name="firstname" position="move" />
             </xpath>
         </field>
     </record>
+
+    <record id="view_res_users_kanban" model="ir.ui.view">
+        <field name="name">res.users.kanban</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_res_users_kanban" />
+        <field name="arch" type="xml">
+            <xpath expr="//templates//field[@name='name']" position="after">
+                <field name="display_fullname" />
+            </xpath>
+            <xpath expr="//templates//field[@name='name']" position="attributes">
+                <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_users_search" model="ir.ui.view">
+        <field name="name">res.users.search</field>
+        <field name="model">res.users</field>
+        <field name="inherit_id" ref="base.view_users_search" />
+        <field name="arch" type="xml">
+            <xpath expr="//search/field[@name='name']" position="attributes">
+                <attribute name="filter_domain">
+                    ['|','|', '|', ('name','ilike',self), ('login','ilike',self), ('email','ilike',self), ('display_fullname','ilike',self)]
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
- Refactor l10n_th_partner
    - Add `display_fullname` for diaplay title (company type), firstname and lastname in the field
    - Delete `name_company` and use `name` standard odoo and oca (no change)
    - Fix bug config `no_space_title` and firstname, lastname will mistake

@newtratip I'm not sure that it will effect with ir_translate, could you check?
@ps-tubtim It will effect with l10n_th_account_tax_report (if it okay, i will fix it)


TODO
- [ ] Test script

Note: merge with nobump