### PR TITLE
[15.0][FIX] l10n_th_account_tax: wht table overflow payment form

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -221,7 +221,12 @@ class AccountMoveLine(models.Model):
         prec = self.env.company.currency_id.decimal_places
         full_tax = abs(float_round(self.tax_line_id.amount / 100 * base, prec))
         # partial payment, we need to compute the base amount
-        if self.tax_line_id and float_compare(full_tax, tax, prec) != 0:
+        partial_payment = self.env.context.get("partial_payment", False)
+        if (
+            partial_payment
+            and self.tax_line_id
+            and float_compare(full_tax, tax, prec) != 0
+        ):
             base = abs(float_round(tax * 100 / self.tax_line_id.amount, prec))
         return sign * base
 

--- a/l10n_th_account_tax/views/account_payment_view.xml
+++ b/l10n_th_account_tax/views/account_payment_view.xml
@@ -124,8 +124,15 @@
                             <field name="date" invisible="1" />
                             <field name="calendar_year" invisible="1" />
                             <field name="partner_id" readonly="1" />
-                            <field name="wht_cert_income_type" />
-                            <field name="wht_cert_income_desc" optional="show" />
+                            <field
+                                name="wht_cert_income_type"
+                                style="white-space: normal;"
+                            />
+                            <field
+                                name="wht_cert_income_desc"
+                                optional="show"
+                                style="white-space: normal;"
+                            />
                             <field name="amount_income" />
                             <field name="amount_wht" />
                             <field name="is_pit" />

--- a/l10n_th_account_tax/wizard/account_payment_register.py
+++ b/l10n_th_account_tax/wizard/account_payment_register.py
@@ -178,8 +178,9 @@ class AccountPaymentRegister(models.TransientModel):
         }
 
     def action_create_payments(self):
-        if self.payment_difference_handling == "reconcile":
-            context = self.env.context.copy()
-            context.update({"skip_account_move_synchronization": True})
-            self = self.with_context(**context)
+        # For case calculate tax invoice partial payment
+        if self.payment_difference_handling == "open":
+            self = self.with_context(partial_payment=True)
+        elif self.payment_difference_handling == "reconcile":
+            self = self.with_context(skip_account_move_synchronization=True)
         return super().action_create_payments()


### PR DESCRIPTION
Fix 2 bug
- withholding tax table is overflows form
- calculate tax amount from partial payment (cherry pick from https://github.com/OCA/l10n-thailand/pull/272/commits/d8b8eb272e9748cfd4ab9d8efa9cf5181e952dd9)

-----------------------------------

When we select type4 wht or add string text is long. it will overflow form payment

Before
![Selection_007](https://user-images.githubusercontent.com/20896369/203518446-22b70621-a813-4f61-9974-f16924284b4d.png)

After
![Selection_008](https://user-images.githubusercontent.com/20896369/203518459-8d1bf99c-0d46-446b-94a8-76d6c1b7d41e.png)
