### PR TITLE
[15.0][FIX] l10n_th_account_asset_management: fix size image tree view

### DIFF
--- a/l10n_th_account_asset_management/__manifest__.py
+++ b/l10n_th_account_asset_management/__manifest__.py
@@ -8,7 +8,7 @@
     "license": "AGPL-3",
     "website": "https://github.com/OCA/l10n-thailand",
     "category": "Localization / Accounting",
-    "depends": ["account_asset_number"],
+    "depends": ["account_asset_number", "web_tree_image_tooltip"],
     "data": ["views/account_asset_views.xml"],
     "installable": True,
     "development_status": "Alpha",


### PR DESCRIPTION
BUG:
Field image in tree view asset have a full image / line
![Selection_034](https://user-images.githubusercontent.com/20896369/223934479-f36c219c-3f7d-48ca-a2e1-7f4b2e584db1.png)

This PR is fix resize image tree view and can zoom in tree view by depend module `web_tree_image_tooltip`
![Selection_035](https://user-images.githubusercontent.com/20896369/223934616-77e34e8f-6118-4793-b209-53cb1124add3.png)
