### PR TITLE
[15.0][FIX] l10n_th_account_tax: allow duplicate PIT Table with other year

### DIFF
--- a/l10n_th_account_tax/tests/test_withholding_tax_pit.py
+++ b/l10n_th_account_tax/tests/test_withholding_tax_pit.py
@@ -107,6 +107,13 @@ class TestWithholdingTaxPIT(TransactionCase):
             with Form(self.pit_rate) as pit_rate:
                 with pit_rate.rate_ids.edit(1) as rate:
                     rate.income_from = 1001
+        # Copy PIT, it will add copy after calendar year
+        # User MUST change to to calendar year
+        pit_rate_copy = self.pit_rate.copy()
+        self.assertEqual(
+            pit_rate_copy.calendar_year, "{} (copy)".format(self.pit_rate.calendar_year)
+        )
+        self.assertFalse(pit_rate_copy.effective_date)
 
     @freeze_time("2001-02-01")
     def test_02_withholding_tax_pit(self):

--- a/l10n_th_account_tax/views/personal_income_tax_view.xml
+++ b/l10n_th_account_tax/views/personal_income_tax_view.xml
@@ -39,6 +39,12 @@
                             <field name="active" />
                         </group>
                     </group>
+                    <span
+                        style="color: red;"
+                        attrs="{'invisible': [('effective_date', '!=', False)]}"
+                    >
+                        *Effective Date is required. Please provide a valid calendar year as an integer.
+                    </span>
                     <separator string="Withholding Tax Rates" />
                     <field name="rate_ids" nolabel="1">
                         <tree editable="bottom">


### PR DESCRIPTION
When duplicate PIT. it will add (copy) after calendar year and you need change it to calendar year because it will not working if you not have effective date

![Selection_018](https://user-images.githubusercontent.com/20896369/225807946-78daeb6a-a7e8-4750-9772-9746b5f467c3.png)
