### PR TITLE
[15.0][FIX] l10n_th_account_tax: fix sign tax invoice refund

### DIFF
--- a/l10n_th_account_tax/models/account_move_tax_invoice.py
+++ b/l10n_th_account_tax/models/account_move_tax_invoice.py
@@ -90,8 +90,9 @@ class AccountMoveTaxInvoice(models.Model):
     def _compute_tax_amount(self):
         """Compute without undue vat"""
         for rec in self._origin.filtered(lambda l: not l.payment_id):
-            rec.tax_base_amount = rec.move_line_id.tax_base_amount or 0.0
-            rec.balance = abs(rec.move_line_id.balance) or 0.0
+            sign = 1 if rec.move_id.move_type not in ["in_refund", "out_refund"] else -1
+            rec.tax_base_amount = sign * rec.move_line_id.tax_base_amount or 0.0
+            rec.balance = sign * abs(rec.move_line_id.balance) or 0.0
 
     @api.depends("move_line_id")
     def _compute_payment_id(self):

--- a/l10n_th_account_tax/models/account_partial_reconcile.py
+++ b/l10n_th_account_tax/models/account_partial_reconcile.py
@@ -42,10 +42,12 @@ class AccountPartialReconcile(models.Model):
                 "DELETE FROM account_move_line WHERE id in %s",
                 (tuple(del_move_lines.ids),),
             )
-        # Back state tax cash basis in bills to draft. waiting clear tax later.
-        for move in moves:
-            if move.tax_cash_basis_origin_move_id.move_type == "in_invoice":
-                move.mapped("line_ids").remove_move_reconcile()
-                move.write({"state": "draft", "is_move_sent": False})
+        # Back state tax cash basis in bills (not include net refund) to draft.
+        # waiting clear tax later.
+        if not self._context.get("net_invoice_refund"):
+            for move in moves:
+                if move.tax_cash_basis_origin_move_id.move_type == "in_invoice":
+                    move.mapped("line_ids").remove_move_reconcile()
+                    move.write({"state": "draft", "is_move_sent": False})
         # --
         return moves


### PR DESCRIPTION
Bug:
- refund customer invoice or vendor bills. tax amount should be negative amount
- state tax cashbasis is mistake when reconcile with refund (error from pr https://github.com/OCA/l10n-thailand/pull/362/files#diff-587f7f49684648bf677f7149e598a42aa1a1d8560160d813582f77981b4232e1R45)
- Not create tax invoice number, if it from manual reconciled customer invoice and credit note