### PR TITLE
[15.0][IMP] l10n_th_gov_account_asset_management: accounting analytic all move line

### DIFF
--- a/l10n_th_gov_account_asset_management/__manifest__.py
+++ b/l10n_th_gov_account_asset_management/__manifest__.py
@@ -17,6 +17,7 @@
         "data/ir_actions_server_data.xml",
         "views/account_asset_views.xml",
         "wizard/account_asset_remove.xml",
+        "views/res_config_settings_views.xml",
     ],
     "installable": True,
     "development_status": "Alpha",

--- a/l10n_th_gov_account_asset_management/models/__init__.py
+++ b/l10n_th_gov_account_asset_management/models/__init__.py
@@ -1,4 +1,7 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
+from . import res_company
+from . import res_config_settings
 from . import account_asset
+from . import account_asset_line
 from . import account_move

--- a/l10n_th_gov_account_asset_management/models/account_asset_line.py
+++ b/l10n_th_gov_account_asset_management/models/account_asset_line.py
@@ -1,0 +1,23 @@
+# Copyright 2023 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import models
+
+
+class AccountAssetLine(models.Model):
+    _inherit = "account.asset.line"
+
+    def _setup_move_line_data(self, depreciation_date, account, ml_type, move):
+        """Prepare data to be propagated to account.move.line"""
+        move_line_data = super()._setup_move_line_data(
+            depreciation_date, account, ml_type, move
+        )
+        if self.env.company.asset_move_line_analytic and ml_type == "depreciation":
+            asset = self.asset_id
+            move_line_data.update(
+                {
+                    "analytic_account_id": asset.account_analytic_id.id,
+                    "analytic_tag_ids": [(4, tag.id) for tag in asset.analytic_tag_ids],
+                }
+            )
+        return move_line_data

--- a/l10n_th_gov_account_asset_management/models/res_company.py
+++ b/l10n_th_gov_account_asset_management/models/res_company.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResCompany(models.Model):
+    _inherit = "res.company"
+
+    asset_move_line_analytic = fields.Boolean(
+        string="Stamp analytic in all asset move line"
+    )

--- a/l10n_th_gov_account_asset_management/models/res_config_settings.py
+++ b/l10n_th_gov_account_asset_management/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# Copyright 2023 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+    _inherit = "res.config.settings"
+
+    asset_move_line_analytic = fields.Boolean(
+        related="company_id.asset_move_line_analytic", readonly=False
+    )

--- a/l10n_th_gov_account_asset_management/views/res_config_settings_views.xml
+++ b/l10n_th_gov_account_asset_management/views/res_config_settings_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.account</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="account.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//div[@id='analytic']" position="inside">
+                <div
+                    class="col-12 col-lg-6 o_setting_box"
+                    id="asset_move_line_analytic"
+                >
+                    <div class="o_setting_left_pane">
+                        <field name="asset_move_line_analytic" />
+                    </div>
+                    <div class="o_setting_right_pane">
+                        <label for="asset_move_line_analytic" />
+                    </div>
+                </div>
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_th_gov_account_asset_management/wizard/account_asset_remove.py
+++ b/l10n_th_gov_account_asset_management/wizard/account_asset_remove.py
@@ -30,3 +30,22 @@ class AccountAssetRemove(models.TransientModel):
             ctx.update({"active_id": asset.id})
             self.with_context(**ctx).remove()
         return True
+
+    def _get_removal_data(self, asset, residual_value):
+        move_lines = super()._get_removal_data(asset, residual_value)
+        if self.env.company.asset_move_line_analytic:
+            analytic_account = asset.account_analytic_id.id
+            analytic_tags = [(4, tag.id) for tag in asset.analytic_tag_ids]
+            move_lines = [
+                (
+                    ml[0],
+                    ml[1],
+                    {
+                        **ml[2],
+                        "analytic_account_id": analytic_account,
+                        "analytic_tag_ids": analytic_tags,
+                    },
+                )
+                for ml in move_lines
+            ]
+        return move_lines


### PR DESCRIPTION
This PR is implement for goverment can config add analytic asset to all move line (create / remove asset)
you can config it in setting > accounting > analytic
![Selection_001](https://user-images.githubusercontent.com/20896369/227151004-75da2bdf-6b94-4ea5-988a-67d59353d5c5.png)

It will stamp analytic account, tag in all account move line
![Selection_002](https://user-images.githubusercontent.com/20896369/227151334-96b8afb5-9279-4c7b-a584-15c407b1b3cf.png)
