### PR TITLE
[15.0][FIX] l10n_th_account_tax: allow reconcile undue case can't register payment

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -362,9 +362,9 @@ class AccountMove(models.Model):
                 ):
                     if tax_invoice.payment_id:  # Defer posting for payment
                         tax_invoice.payment_id.write({"to_clear_tax": True})
-                        return self.browse()  # return False
+                        continue
                     elif self.env.context.get("net_invoice_refund"):
-                        return self.browse()  # return False
+                        continue
                     else:
                         raise UserError(_("Please fill in tax invoice and tax date"))
 

--- a/l10n_th_account_tax/models/account_partial_reconcile.py
+++ b/l10n_th_account_tax/models/account_partial_reconcile.py
@@ -42,5 +42,10 @@ class AccountPartialReconcile(models.Model):
                 "DELETE FROM account_move_line WHERE id in %s",
                 (tuple(del_move_lines.ids),),
             )
+        # Back state tax cash basis in bills to draft. waiting clear tax later.
+        for move in moves:
+            if move.tax_cash_basis_origin_move_id.move_type == "in_invoice":
+                move.mapped("line_ids").remove_move_reconcile()
+                move.write({"state": "draft", "is_move_sent": False})
         # --
         return moves


### PR DESCRIPTION
Step to error:
1. Create Undue vat and allow reconcile this account.
2. Normal process to Register Payment, it will error
![undue](https://user-images.githubusercontent.com/20896369/232451290-4f0d5941-b4ee-4879-849c-ac13a15b5ba1.png)
