### PR TITLE
[15.0][FIX] l10n_th_account_tax: fix bug space table and copy PIT line is not correct

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -515,6 +515,7 @@ class AccountMove(models.Model):
                     {
                         "amount_income": -line.amount_income,
                         "amount_wht": -line.amount_wht,
+                        "calendar_year": line.calendar_year,
                     }
                 )
                 line.cancelled = True

--- a/l10n_th_account_tax/views/res_partner_view.xml
+++ b/l10n_th_account_tax/views/res_partner_view.xml
@@ -30,9 +30,36 @@
                             type="object"
                         />
                     </div>
-                    <group name="pit" string="Personal Income Tax">
-                        <field name="pit_move_ids" nolabel="1" />
-                    </group>
+                    <field name="pit_move_ids" nolabel="1">
+                        <tree editable="bottom" create="1" delete="0">
+                            <field name="partner_id" optional="hide" />
+                            <field name="payment_id" />
+                            <field name="date" optional="show" />
+                            <field name="calendar_year" optional="show" />
+                            <field
+                                name="wht_cert_income_type"
+                                style="white-space: normal;"
+                            />
+                            <field
+                                name="wht_cert_income_desc"
+                                optional="show"
+                                style="white-space: normal;"
+                            />
+                            <field name="amount_income" sum="Total Income" />
+                            <field
+                                name="amount_wht"
+                                sum="Total Amount Withholding Tax"
+                            />
+                            <field name="cancelled" optional="show" />
+                            <field
+                                name="payment_state"
+                                widget="badge"
+                                decoration-info="payment_state == 'draft'"
+                                decoration-success="payment_state == 'posted'"
+                            />
+                            <field name="currency_id" invisible="1" />
+                        </tree>
+                    </field>
                 </page>
             </xpath>
         </field>


### PR DESCRIPTION
Fix bug
1. Table PIT in contact is too long
![Selection_004](https://github.com/OCA/l10n-thailand/assets/20896369/bd142a40-457b-4563-8b2f-95f149a0691c)

2. when cancel payment is PIT, it will copy data not include calendar year. It should copy calenday year.
![Selection_005](https://github.com/OCA/l10n-thailand/assets/20896369/512be82f-5a9c-41a8-b792-3f35bd613b39)
