### PR TITLE
[15.0][ENH] l10n_th_account_tax: auto change report tax late when accounting date and tax invoice date is not a same month

### DIFF
--- a/l10n_th_account_tax/views/account_move_view.xml
+++ b/l10n_th_account_tax/views/account_move_view.xml
@@ -124,6 +124,8 @@
                             <field name="partner_id" optional="hide" />
                             <field name="tax_invoice_number" />
                             <field name="tax_invoice_date" />
+                            <field name="report_late_mo" optional="show" />
+                            <field name="report_date" optional="show" />
                             <field name="tax_base_amount" />
                             <field name="balance" sum="Tax Amount" />
                             <button

--- a/l10n_th_account_tax/views/account_payment_view.xml
+++ b/l10n_th_account_tax/views/account_payment_view.xml
@@ -101,6 +101,12 @@
                                     name="tax_invoice_date"
                                     attrs="{'readonly': [('to_clear_tax', '=', False)]}"
                                 />
+                                <field
+                                    name="report_late_mo"
+                                    attrs="{'readonly': [('to_clear_tax', '=', False)]}"
+                                    optional="show"
+                                />
+                                <field name="report_date" optional="show" />
                                 <field name="tax_base_amount" />
                                 <field name="balance" sum="Total Tax" />
                                 <button


### PR DESCRIPTION
This PR is enhance account tax thailand when user select accounting date and tax invoice date is not a same month
it will auto change report late by Accounting Date - Tax Invoice Date and difference is range 1 - 6 month only.
other case will not change

- Add `Report Late`, `Report Date` in `Tax Invoice` Tab (include Payment)
- Add onchange when `Tax Invoice Date` is change by Accounting Date (Move) - Tax Invoice Date

![Selection_001](https://github.com/OCA/l10n-thailand/assets/20896369/d7796765-1e46-4de4-84b6-e3988539b08b)
