### PR TITLE
[15.0][FIX] l10n_th_account_tax: add domain purchase taxes with type_tax_use

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -359,6 +359,7 @@ class AccountMove(models.Model):
                     l.move_id.move_type == "entry"
                     and not l.payment_id
                     and l.move_id.journal_id.type != "sale"
+                    and l.tax_line_id.type_tax_use != "sale"
                 )
             ):
                 if (


### PR DESCRIPTION
Step to test:
1. install module "Point of Sale" and "l10n_th_account_tax"
2. when close session POS it will error because move type is entry and journal is not sale

![Selection_013](https://github.com/OCA/l10n-thailand/assets/20896369/c2f37b52-b810-4007-bc39-aaaa985a4888)


Fix it by check condition tax_line_id.type_tax_use != "sale" for skip when POS is close