### PR TITLE
[15.0][FIX] l10n_th_account_tax: can't reset payment with undue vat

### DIFF
--- a/l10n_th_account_tax/models/account_partial_reconcile.py
+++ b/l10n_th_account_tax/models/account_partial_reconcile.py
@@ -42,9 +42,11 @@ class AccountPartialReconcile(models.Model):
                 "DELETE FROM account_move_line WHERE id in %s",
                 (tuple(del_move_lines.ids),),
             )
-        # Back state tax cash basis in bills (not include net refund) to draft.
+        # Back state tax cash basis in bills to draft (not include net refund and payment).
         # waiting clear tax later.
-        if not self._context.get("net_invoice_refund"):
+        net_invoice_refund = self.env.context.get("net_invoice_refund")
+        net_invoice_payment = self.env.context.get("net_invoice_payment")
+        if not net_invoice_refund or net_invoice_payment:
             for move in moves:
                 if move.tax_cash_basis_origin_move_id.move_type == "in_invoice":
                     move.mapped("line_ids").remove_move_reconcile()

--- a/l10n_th_account_tax/models/account_payment.py
+++ b/l10n_th_account_tax/models/account_payment.py
@@ -78,7 +78,8 @@ class AccountPayment(models.Model):
                 move.action_post()
                 # Reconcile Case Basis
                 line = move.line_ids.filtered(
-                    lambda l: l.id != payment.tax_invoice_ids.move_line_id.id
+                    lambda l: l.id
+                    not in payment.tax_invoice_ids.mapped("move_line_id").ids
                 )
                 if line.account_id.reconcile:
                     origin_ml = move.tax_cash_basis_origin_move_id.line_ids


### PR DESCRIPTION
- Fix allow reset to draft on payment undue vat and auto post tax cash basis
- Fix can't clear tax with multi invoices

Step to test:
1. create undue tax with account reconciled
2. create vendor bill with undue tax and register payment
3. reset to draft payment -> error 

![Selection_006](https://github.com/OCA/l10n-thailand/assets/20896369/5ef3e169-4539-409e-b888-b33d7499af33)
