### PR TITLE
[15.0][ENH] l10n_th_account_tax: add tax number in refund, sign of undue

### DIFF
--- a/l10n_th_account_tax/__manifest__.py
+++ b/l10n_th_account_tax/__manifest__.py
@@ -14,6 +14,7 @@
         "security/account_security.xml",
         "security/ir.model.access.csv",
         "wizard/account_payment_register_views.xml",
+        "wizard/account_move_reversal_view.xml",
         "views/res_config_settings_views.xml",
         "views/account_view.xml",
         "views/account_move_view.xml",

--- a/l10n_th_account_tax/models/withholding_tax_cert.py
+++ b/l10n_th_account_tax/models/withholding_tax_cert.py
@@ -63,7 +63,11 @@ WHT_CERT_INCOME_TYPE = [
 ]
 
 
-TAX_PAYER = [("withholding", "Withholding"), ("paid_one_time", "Paid One Time")]
+TAX_PAYER = [
+    ("withholding", "Withholding"),
+    ("paid_one_time", "Paid One Time"),
+    ("paid_continue", "Paid Continuously"),
+]
 
 
 class WithholdingTaxCert(models.Model):

--- a/l10n_th_account_tax/tests/test_withholding_tax_pit.py
+++ b/l10n_th_account_tax/tests/test_withholding_tax_pit.py
@@ -13,7 +13,6 @@ class TestWithholdingTaxPIT(TransactionCase):
     @classmethod
     @freeze_time("2001-02-01")
     def setUpClass(cls):
-        """Assign user and department."""
         super().setUpClass()
         cls.partner = cls.env["res.partner"].create({"name": "Test Partner"})
         cls.product = cls.env["product.product"].create(

--- a/l10n_th_account_tax/wizard/__init__.py
+++ b/l10n_th_account_tax/wizard/__init__.py
@@ -1,6 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
 from . import account_payment_register
-
-# from . import create_withholding_tax_cert
-# from . import create_pit_withholding_tax_cert
+from . import account_move_reversal

--- a/l10n_th_account_tax/wizard/account_move_reversal.py
+++ b/l10n_th_account_tax/wizard/account_move_reversal.py
@@ -1,0 +1,20 @@
+# Copyright 2023 Ecosoft Co., Ltd (https://ecosoft.co.th/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo import fields, models
+
+
+class AccountMoveReversal(models.TransientModel):
+    _inherit = "account.move.reversal"
+
+    tax_invoice_number = fields.Char(copy=False)
+    tax_invoice_date = fields.Date(copy=False)
+
+    def reverse_moves(self):
+        self.ensure_one()
+        if self.move_type == "in_invoice":
+            self = self.with_context(
+                tax_invoice_number=self.tax_invoice_number,
+                tax_invoice_date=self.tax_invoice_date,
+            )
+        return super().reverse_moves()

--- a/l10n_th_account_tax/wizard/account_move_reversal_view.xml
+++ b/l10n_th_account_tax/wizard/account_move_reversal_view.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_account_move_reversal" model="ir.ui.view">
+        <field name="name">account.move.reversal.form</field>
+        <field name="model">account.move.reversal</field>
+        <field name="inherit_id" ref="account.view_account_move_reversal" />
+        <field name="arch" type="xml">
+            <xpath expr="/form/group[1]/group[1]" position="inside">
+                <field
+                    name="tax_invoice_number"
+                    attrs="{'invisible': [('move_type', '!=', 'in_invoice')]}"
+                />
+                <field
+                    name="tax_invoice_date"
+                    attrs="{'invisible': [('move_type', '!=', 'in_invoice')]}"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR cherry-pick from https://github.com/OCA/l10n-thailand/pull/394

- Fixed an issue that occurred during a full refund on a vendor bill. The error occurred because the new refund did not have a tax invoice number. This commit adds the tax invoice number and date to the wizard during reversal.
![Selection_001](https://github.com/OCA/l10n-thailand/assets/20896369/a2f6e1ae-1369-4f12-b210-3a349761d4c4)
This PR add `Tax Invoice Number` and `Tax Invoice Date` on wizard reversal
![Selection_002](https://github.com/OCA/l10n-thailand/assets/20896369/af7621cb-51a1-40d1-932a-ed9e4f16872b)

----------------------------------------

- Correct tax sign reversal in the accounting move for undue transactions.
![Selection_003](https://github.com/OCA/l10n-thailand/assets/20896369/4ae94861-1c36-49ce-b60a-3ffdbb839b9c)
when register payment with undue vat of reversal move (vendor bill). sign of tax should be negative but this is positive sign
![Selection_004](https://github.com/OCA/l10n-thailand/assets/20896369/754c2358-85b5-4221-b2d4-3b141045d328)

----------------------------------------

- add `Paid Continuously` option on Tax Payee of withholding tax document
![Selection_005](https://github.com/OCA/l10n-thailand/assets/20896369/747bdec5-23ce-4a03-a7bc-57ca1a973c9f)


