### PR TITLE
[15.0][FIX] l10n_th_account_tax_report: query mistake

### DIFF
--- a/l10n_th_account_tax_report/reports/tax_report.py
+++ b/l10n_th_account_tax_report/reports/tax_report.py
@@ -92,8 +92,13 @@ class TaxReport(models.TransientModel):
                 -- and late report date within range date end
                 and (
                     (t.report_date >= %s and t.report_date <= %s)
-                    or (t.report_late_mo != '0' and EXTRACT(MONTH FROM t.report_date) <= %s
-                        and EXTRACT(YEAR FROM t.report_date) <= %s)
+                    or (
+                        t.report_late_mo != '0' and
+                        EXTRACT(MONTH FROM t.report_date) <= %s and
+                        EXTRACT(YEAR FROM t.report_date) <= %s and
+                        EXTRACT(MONTH FROM t.report_date) >= %s and
+                        EXTRACT(YEAR FROM t.report_date) >= %s
+                    )
                 )
                 and ml.company_id = %s
                 and t.reversed_id is null
@@ -113,6 +118,8 @@ class TaxReport(models.TransientModel):
                 self.date_to,
                 self.date_to.month,
                 self.date_to.year,
+                self.date_from.month,
+                self.date_from.year,
                 self.company_id.id,
             ),
         )


### PR DESCRIPTION
Fix bug query account tax report when it has a report late.

This PR is fixed query following:

Example Case:
We have tax invoice 7 document
```
ID	Tax Invoice	Late	Report Date
1	09/11/23	0	09/11/23
2	11/10/23	1	30/11/23
3	30/11/23	0	30/11/23
4	30/10/23	0	30/10/23
5	03/09/23	2	30/11/23
6	14/04/22	4	14/08/22
7	16/08/23	2	31/10/23

```

Filter thai tax report 01/11/23 - 30/11/23
it should be result ID 1, 2, 3, 5

Filter thai tax report 01/11/23 - 15/11/23
it should be result ID 1, 2, 5

Filter thai tax report 30/10/23 - 01/11/23
it should be result ID 2, 4, 5, 7