### PR TITLE
[15.0][FIX] l10n_th_account_tax: rounding wht_percent

### DIFF
--- a/l10n_th_account_tax/models/withholding_tax_cert.py
+++ b/l10n_th_account_tax/models/withholding_tax_cert.py
@@ -3,6 +3,7 @@
 
 from odoo import _, api, fields, models
 from odoo.exceptions import UserError
+from odoo.tools import float_round
 
 INCOME_TAX_FORM = [
     ("pnd1", "PND1"),
@@ -258,7 +259,12 @@ class WithholdingTaxCertLine(models.Model):
     def _compute_wht_percent(self):
         for rec in self:
             rec.wht_percent = (
-                rec.wht_tax_id.amount or rec.base and (rec.amount / rec.base) * 100
+                rec.wht_tax_id.amount
+                or rec.base
+                and float_round(
+                    (rec.amount / rec.base) * 100,
+                    precision_rounding=rec.company_id.currency_id.rounding,
+                )
             )
 
     @api.onchange("wht_cert_income_type")


### PR DESCRIPTION
This PR fixed rounding on wht_percent for reporting

Step to test:
1. Install module `l10n_th_account_tax` and `l10n_th_account_tax_report`
2. create wht with base amount = 41094.23 and Tax amount = 410.94 (wht percent 1%)
![Selection_001](https://github.com/OCA/l10n-thailand/assets/20896369/60a5c03b-f791-4c68-82e9-61383419b436)

3. Go to Reporting > WHT Income Tax Report > View or Export TXT. it will wrong value
![Selection_002](https://github.com/OCA/l10n-thailand/assets/20896369/a563dfca-0693-4961-a380-e0f2caec3d38)
![Selection_003](https://github.com/OCA/l10n-thailand/assets/20896369/8aa53ceb-6d15-4576-b491-1c07082dd230)
