### PR TITLE
[15.0][FIX] l10n_th_multi_currency_revaluation: condition for skip revalue

### DIFF
--- a/l10n_th_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
+++ b/l10n_th_multicurrency_revaluation/wizard/wizard_currency_revaluation.py
@@ -351,7 +351,7 @@ class WizardCurrencyRevaluation(models.TransientModel):
                             float_compare(
                                 rate,
                                 ml_origin.revaluation_created_line_id.gl_currency_rate,
-                                precision_rounding=currency.rounding,
+                                precision_digits=12,
                             )
                             == 0
                             and not move_reversed


### PR DESCRIPTION
This PR fixed compare with 12 digits only when revalue multi times

Step to test:
1. create document with multi currency for revalue (01/10/2023)
2. revalue to 31/10/2023 (rate = 20.001234567890)
3. revalue to 30/11/2023 (rate = 19.999999999999)
4. it will not revalue because condition compare between 20.001234567890 and 19.999999999999 will rounding from currency (2 digits default)
