### PR TITLE
[15.0][FIX] l10n_th_account_tax: Clear undue tax expense with multiple undue tax lines will throw error

### DIFF
--- a/l10n_th_account_tax/models/account_payment.py
+++ b/l10n_th_account_tax/models/account_payment.py
@@ -86,6 +86,12 @@ class AccountPayment(models.Model):
                     counterpart_line = origin_ml.filtered(
                         lambda l: l.account_id.id == line.account_id.id
                     )
+                    # Get counterpart line for expense
+                    credit_move = move.tax_cash_basis_rec_id.credit_move_id
+                    if hasattr(credit_move, "expense_id") and credit_move.expense_id:
+                        counterpart_line = counterpart_line.filtered(
+                            lambda l: l.expense_id.id == credit_move.expense_id.id
+                        )
                     (line + counterpart_line).reconcile()
         return True
 


### PR DESCRIPTION
**Step to test**

1. Create multiple expense lines with undue tax
2. Post Journal Entry
3. Register Payment
4. Go to payment and input tax number and tax invoice date
5. Clear Tax, it will throw error "You are trying to reconcile some entries that are already reconciled"

<img width="745" alt="image" src="https://github.com/OCA/l10n-thailand/assets/24691983/9e1c9adf-d676-41f2-894c-9829306ce2f1">

Could you please review ?
@Saran440 
