### PR TITLE
[15.0][FIX] l10n_th_account_tax_report: Tax date (Year B.E.) is not correct on the report (PDF type)

### DIFF
--- a/l10n_th_account_tax_report/reports/report_withholding_tax.py
+++ b/l10n_th_account_tax_report/reports/report_withholding_tax.py
@@ -1,7 +1,6 @@
 # Copyright 2019 Ecosoft Co., Ltd (https://ecosoft.co.th/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
-from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
 
@@ -179,9 +178,11 @@ class WithHoldingTaxReport(models.TransientModel):
         return 3  # Paid One Time
 
     def format_date_dmy(self, date, format_date=None):
+        if format_date is None:
+            format_date = "{day}{month}{year}"
         year_thai = date.year + 543
-        date_format = "{}{}{}".format(
-            str(date.day).zfill(2), str(date.month).zfill(2), year_thai
+        date_format = format_date.format(
+            day=str(date.day).zfill(2), month=str(date.month).zfill(2), year=year_thai
         )
         return date_format
 
@@ -334,7 +335,9 @@ class WithHoldingTaxReport(models.TransientModel):
             "partner_firstname": firstname,
             "partner_lastname": lastname,
             "partner_address": address,
-            "date": (line.cert_id.date + relativedelta(years=543)).strftime("%d/%m/%Y"),
+            "date": self.format_date_dmy(
+                line.cert_id.date, format_date="{day}/{month}/{year}"
+            ),
             "tax_payer": tax_payer,
             "total_base": 0.0,
             "total_amount": 0.0,

--- a/l10n_th_account_tax_report/reports/tax_report.py
+++ b/l10n_th_account_tax_report/reports/tax_report.py
@@ -163,6 +163,15 @@ class TaxReport(models.TransientModel):
     def get_html(self, given_context=None):
         return self.with_context(**given_context)._get_html()
 
+    def format_tax_date(self, date, format_date=None):
+        if format_date is None:
+            format_date = "{day}{month}{year}"
+        year_thai = date.year + 543
+        date_format = format_date.format(
+            day=str(date.day).zfill(2), month=str(date.month).zfill(2), year=year_thai
+        )
+        return date_format
+
     def _get_period_be(self, date_start, date_end):
         month = year = "-"
         date_start = (date_start + relativedelta(years=543)).strftime("%m-%Y")

--- a/l10n_th_account_tax_report/reports/tax_report_rd.xml
+++ b/l10n_th_account_tax_report/reports/tax_report_rd.xml
@@ -223,18 +223,20 @@
                                 <t t-set="total_base" t-value="0.00" />
                                 <t t-set="total_tax" t-value="0.00" />
                                 <t t-foreach="result" t-as="line">
+                                    <t t-set="n" t-value="n + 1" />
+                                    <t
+                                        t-set="tax_date_format"
+                                        t-value="line.tax_date and o.format_tax_date(line.tax_date, format_date='{day}/{month}/{year}')"
+                                    />
                                     <tr>
                                         <td
                                             class="text-center"
                                             style="border-left: 1px solid black;"
                                         >
-                                            <t t-set="n" t-value="n + 1" />
                                             <span t-out="n" />
                                         </td>
                                         <td>
-                                            <span
-                                                t-out="(line.tax_date + relativedelta(years=543)).strftime('%d/%m/%Y')"
-                                            />
+                                            <span t-out="tax_date_format" />
                                         </td>
                                         <td>
                                             <span t-out="line.tax_invoice_number" />


### PR DESCRIPTION
### Step to error

1. Tax date on tax invoice = 29/02/2024 (Year A.D.)
2. Print Tax Report (PDF) will show tax date = 28/02/2567 (Year B.E.), That is wrong tax date

@Saran440 , Could you please review ?