### PR TITLE
[16.0][FIX] l10n_th_partner: translate employee base

### DIFF
--- a/l10n_th_partner/models/__init__.py
+++ b/l10n_th_partner/models/__init__.py
@@ -5,4 +5,4 @@ from . import res_config_settings
 from . import res_partner_company_type
 from . import res_partner
 from . import resource
-from . import hr_employee
+from . import hr_employee_base

--- a/l10n_th_partner/models/hr_employee_base.py
+++ b/l10n_th_partner/models/hr_employee_base.py
@@ -4,7 +4,7 @@
 from odoo import fields, models
 
 
-class HrEmployee(models.Model):
-    _inherit = "hr.employee"
+class HrEmployeeBase(models.AbstractModel):
+    _inherit = "hr.employee.base"
 
     name = fields.Char(translate=True)


### PR DESCRIPTION
When field name in hr.employee can translate and user don't have permission employee, it will error
![Selection_016](https://github.com/OCA/l10n-thailand/assets/20896369/3d377b1c-f072-4974-b597-4754da898f9f)
![Selection_017](https://github.com/OCA/l10n-thailand/assets/20896369/8b3e2843-205d-41e3-8f7a-2dc814829846)
