### PR TITLE
[16.0][FIX] l10n_th_account_tax: no rounding wht same as standard

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -73,10 +73,7 @@ class AccountMoveLine(models.Model):
             amount_wht = 0
             for line in wht_lines:
                 base_amount = line._get_wht_base_amount(currency, wht_date)
-                amount_wht += float_round(
-                    line.wht_tax_id.amount / 100 * base_amount,
-                    precision_digits=currency.decimal_places,
-                )
+                amount_wht += line.wht_tax_id.amount / 100 * base_amount
                 amount_base += base_amount
             return (amount_base, amount_wht)
         # PIT


### PR DESCRIPTION
Step to test:
1. Create 2 bill and use amount from image with 1% WHT
![Selection_003](https://github.com/OCA/l10n-thailand/assets/20896369/1c1c6367-277f-487a-87e3-41cf3d135b72)
![Selection_004](https://github.com/OCA/l10n-thailand/assets/20896369/42ee03be-66c8-43e5-8caf-5d367c67755b)
2. Register payment from 2 bills. it show 23,891.63, payment diff = 241.33
![Selection_005](https://github.com/OCA/l10n-thailand/assets/20896369/7a021560-0930-4591-9ca2-1a6053bbb3c5)

3. After that, change payment date. it will recompute and get amount 23,891.62, payment diff = 241.34
![Selection_006](https://github.com/OCA/l10n-thailand/assets/20896369/cd5231ea-a795-4d1a-b370-34a5701fe37e)

payment diff should 241.33. it because we rounding wht each line.
This PR fixed it to not rounding