### PR TITLE
[15.0][FIX] l10n_th_gov_hr_expense: change options

### DIFF
--- a/l10n_th_gov_hr_expense/views/hr_expense_views.xml
+++ b/l10n_th_gov_hr_expense/views/hr_expense_views.xml
@@ -25,7 +25,7 @@
                 <field
                     name="purchase_request_id"
                     attrs="{'invisible': [('advance_sheet_id', '!=', False)]}"
-                    options="{'no_open': True, 'no_create_edit': True}"
+                    options="{'no_create_edit': True}"
                     groups="purchase_request.group_purchase_request_user"
                 />
                 <field


### PR DESCRIPTION
Remove " 'no_open': True " in field options for make the purchase request clickable.