### PR TITLE
[16.0][FIX] l10n_th_account_tax:Unlink all tax when manual_tax_invoice change from True to False

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -188,7 +188,8 @@ class AccountMoveLine(models.Model):
                         }
                     )
                     line.tax_invoice_ids |= taxinv
-            else:
+            # Unlink all tax invoice, when manual_tax_invoice change from True to False
+            elif self.manual_tax_invoice and vals["manual_tax_invoice"] is False:
                 self = self.with_context(force_remove_tax_invoice=True)
                 self.mapped("tax_invoice_ids").unlink()
         # For case change type taxes, check cash basis


### PR DESCRIPTION
Unlink all tax when manual_tax_invoice change from True to False

ISSUES : 
When the Invoice Date is updated, all Journal Items are recomputed, and some lines have the manual_tax_invoice field updated to False.

This occurs when excess amounts are rounded off (to match the supported coin denominations) and there are more than 40 Journal Items.

This issue is resolved by deleting only the lines where the manual_tax_invoice field changes from True to False.
