### PR TITLE
[15.0][FIX] l10n_th_account_tax: not delete account reconciled

### DIFF
--- a/l10n_th_account_tax/models/account_partial_reconcile.py
+++ b/l10n_th_account_tax/models/account_partial_reconcile.py
@@ -45,9 +45,11 @@ class AccountPartialReconcile(models.Model):
         )
         del_ml_groups = list(filter(lambda l: l["debit"] == l["credit"], ml_groups))
         account_ids = [g.get("account_id")[0] for g in del_ml_groups]
-        # Not include taxes (0%)
+        # Not include taxes (0%) and not reconciled
         del_move_lines = moves.mapped("line_ids").filtered(
-            lambda l: l.account_id.id in account_ids and not l.tax_line_id
+            lambda line: line.account_id.id in account_ids
+            and not line.tax_line_id
+            and not line.reconciled
         )
         if del_move_lines:
             self.env.cr.execute(


### PR DESCRIPTION
Step to test:
1. create withholding tax and undue tax within line
2. when register payment, it will error because it will delete account reconciled