### PR TITLE
[16.0][FIX] l10n_th_account_tax: create wht move only for journal item with a wht id

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -545,7 +545,9 @@ class AccountMove(models.Model):
         #   but still need to keep track the withholding.move base amount
         for move in self:
             # Normal case, create withholding.move only when withholding
-            wht_moves = move.line_ids.filtered("account_id.wht_account")
+            wht_moves = move.line_ids.filtered(
+                lambda l: l.account_id.wht_account and l.wht_tax_id
+            )
             withholding_moves = [
                 Command.create(self._prepare_withholding_move(wht_move))
                 for wht_move in wht_moves


### PR DESCRIPTION
**Before fix, if there was a journal item marked as WHT, odoo would generate a WHT move even if there was no WHT ID.** 

![image](https://github.com/user-attachments/assets/5106d1e0-12de-4697-ac02-fa86ab9eca98)
![image](https://github.com/user-attachments/assets/f8c43749-fc52-4302-bf39-dbf0e899e91b)

**If there were two WHT journal items and one of them required creating WHT certificates, odoo would attempt to retrieve all WHT moves to create the certificates. This caused an error because a WHT ID could not be found**

![image](https://github.com/user-attachments/assets/5bb4fb3c-99aa-4e97-840f-e03edc78f9c9)

**After the fix, odoo will create WHT moves only for journal items with a WHT ID. As a result, when generating WHT certificates, no errors will occur as previously.**

![image](https://github.com/user-attachments/assets/d7d8bb8f-599b-4a50-b7fe-bdfbe9c29ef1)
