### PR TITLE
[15.0][FIX] l10n_th_account_tax: reverse move tax number

### DIFF
--- a/l10n_th_account_tax/wizard/account_move_reversal.py
+++ b/l10n_th_account_tax/wizard/account_move_reversal.py
@@ -12,9 +12,28 @@ class AccountMoveReversal(models.TransientModel):
 
     def reverse_moves(self):
         self.ensure_one()
+        # Send context to reverse moves for case Full Refund
+        # because it will auto post moves
         if self.move_type == "in_invoice":
             self = self.with_context(
                 tax_invoice_number=self.tax_invoice_number,
                 tax_invoice_date=self.tax_invoice_date,
             )
-        return super().reverse_moves()
+        action = super().reverse_moves()
+
+        # Reverse moves with Partial Refund or Full refund and new draft invoice
+        # Update tax invoice number and tax invoice date
+        if (
+            self.move_type == "in_invoice"
+            and self.tax_invoice_number
+            and self.tax_invoice_date
+        ):
+            move_resversal = self.env[action["res_model"]].browse(action["res_id"])
+            if not move_resversal.tax_invoice_ids.mapped("tax_invoice_number"):
+                move_resversal.tax_invoice_ids.write(
+                    {
+                        "tax_invoice_number": self.tax_invoice_number,
+                        "tax_invoice_date": self.tax_invoice_date,
+                    }
+                )
+        return action


### PR DESCRIPTION
Step to test:
1. reverse move with Partial Refund or Full refund and new draft invoice, it will not send value tax invoice number and date to tax invoices
![Selection_007](https://github.com/user-attachments/assets/de5d2bd5-4689-4373-b25d-a8ffee644d2e)
