### PR TITLE
[15.0][fix] l10n_th_account_tax: skip error

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -399,6 +399,9 @@ class AccountMove(models.Model):
                     # Skip Error when found refund
                     elif self.env.context.get("net_invoice_refund"):
                         continue
+                    # Skip Error when the origin of tax cash basis has move_type in ("in_refund", "out_refund", "in_invoice", "out_invoice")
+                    elif move.tax_cash_basis_origin_move_id.move_type in ("in_refund", "out_refund", "in_invoice", "out_invoice"):
+                        continue
                     else:
                         raise UserError(_("Please fill in tax invoice and tax date"))
 


### PR DESCRIPTION
This error occurred when user try to reset to draft DN document with tax cash basis move.

Even if we fill tax invoice and tax date it still get this error because it check tax invoice and tax date from reverse move
and there is no condition to escape this error. 

I skip error by checking if tax_cash_basis_origin_move_id.move_type  in `("in_refund", "out_refund", "in_invoice", "out_invoice")`