### PR TITLE
[15.0][FIX] l10n_th_gov_purchase_report: convert to amount company with currency rate

### DIFF
--- a/l10n_th_gov_purchase_report/reports/purchase_tracking_report_xlsx.py
+++ b/l10n_th_gov_purchase_report/reports/purchase_tracking_report_xlsx.py
@@ -315,13 +315,10 @@ class ReportPurchaseTrackingReportXlsx(models.AbstractModel):
                 pr.date_approved,
             )
         po_total_company_currency = po.amount_total
+        # Convert to company currency
         if po.currency_id != po.company_id.currency_id:
-            po_total_company_currency = po.currency_id._convert(
-                po_total_company_currency,
-                po.company_id.currency_id,
-                po.company_id,
-                po.date_approve,
-            )
+            po_total_company_currency = po_total_company_currency / po.currency_rate
+
         return {
             "number": i,
             "pr_name": pr.name or "",


### PR DESCRIPTION
This PR fixed error when export purchase tracking report with document po is multi currency but state draft

Step to test:
1. Create purchase document with multi currency with state draft
2. Go to menu Purchase Requests > Reports > Purchase Tracking Report
3. Export XLSX
