### PR TITLE
[15.0][FIX] l10n_th_account_tax: Skip error when unreconcile tax cash basis

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -350,6 +350,13 @@ class AccountMove(models.Model):
         self = self.with_context(net_invoice_refund=True)
         return super().js_assign_outstanding_line(line_id)
 
+    def js_remove_outstanding_partial(self, partial_id):
+        # If you unreconcile with Journal Entry, it will create reverse tax cash basis
+        # Which raise error require tax number and tax invoice so we send context to
+        # skip this error.
+        self = self.with_context(net_invoice_refund=True)
+        return super().js_remove_outstanding_partial(partial_id)
+
     def _post(self, soft=True):
         """Additional tax invoice info (tax_invoice_number, tax_invoice_date)
         Case sales tax, use Odoo's info, as document is issued out.


### PR DESCRIPTION
Step to `UserError(_("Please fill in tax invoice and tax date"))`
When user create vendor bill (with Undue Input Vat)
![image](https://github.com/user-attachments/assets/0c5511a3-5eae-42f3-8e7a-205a2894e1ad)
![image](https://github.com/user-attachments/assets/37e826f3-b5ab-4a1d-9fa4-fad981dff994)


After that, I create journal entry as below
![image](https://github.com/user-attachments/assets/c548887c-131d-4e54-ad73-da48ce21c0b6)


Then reconcile with Journal Entry by click add button
![image](https://github.com/user-attachments/assets/4687f8db-4973-475a-ae03-5f26e21cb9ff)

If I unreconcile it will throw an user error
![image](https://github.com/user-attachments/assets/56d1c70f-6c40-4553-b37b-a1cc342ecfd9)
![image](https://github.com/user-attachments/assets/6fd61db6-c7ff-41f4-a12e-f6b0b83dc160)

