### PR TITLE
[15.0][FIX] l10n_th_account_tax: show currency on tax invoices and calculate tax base

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -118,7 +118,7 @@ class AccountMoveLine(models.Model):
         self.ensure_one()
         base = abs(self.tax_base_amount)
         tax = abs(self.balance)
-        prec = self.env.company.currency_id.decimal_places
+        prec = self.company_id.currency_id.decimal_places
         full_tax = abs(float_round(self.tax_line_id.amount / 100 * base, prec))
         # partial payment, we need to compute the base amount
         partial_payment = self.env.context.get("partial_payment", False)
@@ -127,7 +127,13 @@ class AccountMoveLine(models.Model):
             and self.tax_line_id
             and float_compare(full_tax, tax, prec) != 0
         ):
-            base = abs(float_round(tax * 100 / self.tax_line_id.amount, prec))
+            payment_id = self.env.context.get("payment_id")
+            if payment_id:
+                payment = self.env["account.payment"].browse(payment_id)
+                amount_base = payment.amount - tax
+            else:
+                amount_base = (tax * 100) / self.tax_line_id.amount
+            base = abs(float_round(amount_base, prec))
         return sign * base
 
     @api.model_create_multi

--- a/l10n_th_account_tax/tests/test_tax_invoice.py
+++ b/l10n_th_account_tax/tests/test_tax_invoice.py
@@ -364,7 +364,7 @@ class TestTaxInvoice(TransactionCase):
         action = self.supplier_invoice_undue_vat_partial.action_register_payment()
         ctx = action.get("context")
 
-        # Make full payment from invoice
+        # Keep open
         with Form(self.env["account.payment.register"].with_context(**ctx)) as f:
             f.journal_id = self.journal_bank
             f.amount = 30
@@ -376,9 +376,9 @@ class TestTaxInvoice(TransactionCase):
         self.assertEqual(payment.amount, 30.00)
         self.assertEqual(payment.reconciled_bill_ids.payment_state, "partial")
         self.assertEqual(payment.reconciled_bill_ids.amount_residual, 77)
+
         tax_calculated = 1.96  # payment - (payment * 100)/107
-        # NOTE: tax base amount is not correct because tax_calculated round 2 digits
-        tax_base_cal = (tax_calculated * 100) / 7  # calculat base tax
+        tax_base_cal = payment.amount - tax_calculated  # calculat base tax
         self.assertEqual(payment.tax_invoice_ids.balance, tax_calculated)
         self.assertEqual(payment.tax_invoice_ids.tax_base_amount, tax_base_cal)
         # Not allow delete tax invoice if it has 1 line.

--- a/l10n_th_account_tax/views/account_payment_view.xml
+++ b/l10n_th_account_tax/views/account_payment_view.xml
@@ -110,6 +110,7 @@
                                 <field name="report_date" optional="show" />
                                 <field name="tax_base_amount" />
                                 <field name="balance" sum="Total Tax" />
+                                <field name="company_currency_id" invisible="1" />
                                 <button
                                     name="copy"
                                     string="Split"


### PR DESCRIPTION
This PR fixed 2 case:
1. Add symbol currency in tax invoices table
![Selection_010](https://github.com/user-attachments/assets/fff3cf7d-fdf9-441c-bc88-c9b3d729f7d7)

2. Calculate some amount is mistake when partial payment

Steps to reproduct:
1. Create customer invoice with cash basis (undue) 7% and price is **177,476.64**
![Selection_011](https://github.com/user-attachments/assets/ed8f5b2b-a28c-46cf-ba68-77f01c0e9b17)

2. Register payment with **129,900** and 60,000 is keep open
![Selection_012](https://github.com/user-attachments/assets/d5439520-7e4a-4cde-9ff2-d3c61b447323)

3. After register payment, checked tax base amount. it will calculate tax base amount is **121,401.86** (it should **121,401.87**) because tax_base_amount and balance in move line keep amount following currency digits.
![Selection_013](https://github.com/user-attachments/assets/8f4d9d7c-7274-4aa1-8419-4a97e058663e)

This PR is fixed calculate by `Payment Amount - tax (2 digits)`
