### PR TITLE
[15.0][FIX] l10n_th_account_tax: reverse JE with tax invoice

### DIFF
--- a/l10n_th_account_tax/wizard/account_move_reversal.py
+++ b/l10n_th_account_tax/wizard/account_move_reversal.py
@@ -14,7 +14,7 @@ class AccountMoveReversal(models.TransientModel):
         self.ensure_one()
         # Send context to reverse moves for case Full Refund
         # because it will auto post moves
-        if self.move_type == "in_invoice":
+        if self.move_type in ("in_invoice", "entry"):
             self = self.with_context(
                 tax_invoice_number=self.tax_invoice_number,
                 tax_invoice_date=self.tax_invoice_date,
@@ -24,7 +24,7 @@ class AccountMoveReversal(models.TransientModel):
         # Reverse moves with Partial Refund or Full refund and new draft invoice
         # Update tax invoice number and tax invoice date
         if (
-            self.move_type == "in_invoice"
+            self.move_type in ("in_invoice", "entry")
             and self.tax_invoice_number
             and self.tax_invoice_date
         ):

--- a/l10n_th_account_tax/wizard/account_move_reversal_view.xml
+++ b/l10n_th_account_tax/wizard/account_move_reversal_view.xml
@@ -5,14 +5,14 @@
         <field name="model">account.move.reversal</field>
         <field name="inherit_id" ref="account.view_account_move_reversal" />
         <field name="arch" type="xml">
-            <xpath expr="/form/group[1]/group[1]" position="inside">
+            <xpath expr="//group[2]/group[2]" position="inside">
                 <field
                     name="tax_invoice_number"
-                    attrs="{'invisible': [('move_type', '!=', 'in_invoice')]}"
+                    attrs="{'invisible': [('move_type', 'not in', ['in_invoice', 'entry'])]}"
                 />
                 <field
                     name="tax_invoice_date"
-                    attrs="{'invisible': [('move_type', '!=', 'in_invoice')]}"
+                    attrs="{'invisible': [('move_type', 'not in', ['in_invoice', 'entry'])]}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
Step to test:
1. Create journal entry with tax > Post
![Selection_006](https://github.com/user-attachments/assets/a81c7dcb-8590-40d7-b962-ed451f65af23)

2. Reverse Entry > Reverse
3. it will error `Please fill in tax invoice and tax date`


This PR fixed
1. Condition to see `Tax Invoice Number` field from `in_invoice` only to `in_invoice` or `entry`
2. Position Tax Invoice Number and Tax Invoice Date

Add credit note
![Selection_008](https://github.com/user-attachments/assets/08fc6202-c672-4e0c-a66e-b97d6fed43fd)

Reverse Entry
![Selection_007](https://github.com/user-attachments/assets/0bf89d21-f75e-4a77-a9f7-1e9960d7000f)


@TheerayutEncoder 
