### PR TITLE
[15.0][FIX] l10n_th_multicurrency_revaluation: multi-company

### DIFF
--- a/l10n_th_multicurrency_revaluation/models/res_company.py
+++ b/l10n_th_multicurrency_revaluation/models/res_company.py
@@ -72,7 +72,10 @@ class ResCompany(models.Model):
     currency_reval_journal_id = fields.Many2one(
         comodel_name="account.journal",
         string="Currency gain & loss Default Journal",
-        domain=[("type", "=", "general")],
+        domain=lambda self: [
+            ("type", "=", "general"),
+            ("company_id", "=", self.env.company.id),
+        ],
     )
     auto_post_entries = fields.Boolean(
         string="Auto Post Created Entries",

--- a/l10n_th_multicurrency_revaluation/models/res_config.py
+++ b/l10n_th_multicurrency_revaluation/models/res_config.py
@@ -47,10 +47,9 @@ class AccountConfigSettings(models.TransientModel):
         related="company_id.provision_pl_analytic_account_id",
         readonly=False,
     )
-    default_currency_reval_journal_id = fields.Many2one(
+    currency_reval_journal_id = fields.Many2one(
         comodel_name="account.journal",
         related="company_id.currency_reval_journal_id",
-        default_model="res.company",
         readonly=False,
     )
     auto_post_entries = fields.Boolean(

--- a/l10n_th_multicurrency_revaluation/views/res_config_view.xml
+++ b/l10n_th_multicurrency_revaluation/views/res_config_view.xml
@@ -49,11 +49,11 @@
                             <div class="content-group">
                                 <div class="row mt16">
                                     <label
-                                        for="default_currency_reval_journal_id"
+                                        for="currency_reval_journal_id"
                                         class="col-md-3 o_light_label"
                                     />
                                     <field
-                                        name="default_currency_reval_journal_id"
+                                        name="currency_reval_journal_id"
                                         options="{'no_create_edit': True, 'no_open': True}"
                                     />
                                 </div>


### PR DESCRIPTION
- Add domain in field `currency_reval_journal_id` for each company
- Rename `default_currency_reval_journal_id` to `currency_reval_journal_id` and not used `default_model="res.company",`