### PR TITLE
[15.0][FIX] l10n_th_account_tax: Update tax invoice on manual reconcile

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -441,22 +441,20 @@ class AccountMove(models.Model):
 
         res = super()._post(soft=soft)
 
-        # Sales Taxes (exclude reconcile manual)
-        if not self.env.context.get("net_invoice_refund"):
-            for move in self:
-                for tax_invoice in move.tax_invoice_ids.filtered(
-                    lambda l: l.tax_line_id.type_tax_use == "sale"
-                    or l.move_id.journal_id.type == "sale"
-                ):
-                    tinv_number, tinv_date = self._get_tax_invoice_number(
-                        move, tax_invoice, tax_invoice.tax_line_id
-                    )
-                    tax_invoice.write(
-                        {
-                            "tax_invoice_number": tinv_number,
-                            "tax_invoice_date": tinv_date,
-                        }
-                    )
+        for move in self:
+            for tax_invoice in move.tax_invoice_ids.filtered(
+                lambda l: l.tax_line_id.type_tax_use == "sale"
+                or l.move_id.journal_id.type == "sale"
+            ):
+                tinv_number, tinv_date = self._get_tax_invoice_number(
+                    move, tax_invoice, tax_invoice.tax_line_id
+                )
+                tax_invoice.write(
+                    {
+                        "tax_invoice_number": tinv_number,
+                        "tax_invoice_date": tinv_date,
+                    }
+                )
 
         # Check amount tax invoice with move line
         # kittiu: There are case that we don't want to check


### PR DESCRIPTION
Step to test:
1. create customer invoice with undue
2. register payment
3. reset to draft payment
4. confirm payment and manual reconcile customer invoice and payment again
5. New cash basis will empty tax invoice number (it should value same as payment)