### PR TITLE
[18.0][FIX] l10n_th_account_tax: Create cash basis without sequence

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -250,37 +250,6 @@ class AccountMoveLine(models.Model):
                 deductions.append(deduct)
         return (deductions, amount_deduct)
 
-    def _reconcile_post_hook(self, data):
-        """
-        Case: Vendor Bills only.
-        Reset tax cash basis to draft. until clear tax or reset payment
-        - Bill --> Payment
-            create cash basis (1) is draft
-        - Payment (Posted) --> Payment (Draft)
-            create cash basis (2) and reconcile with (1) state change to posted
-        - Bill manual reconcile payment
-            create cash basis (3) is draft
-        """
-        res = super()._reconcile_post_hook(data)
-        payment_id = self.env.context.get("payment_id")
-        if payment_id:
-            payment = self.env["account.payment"].browse(payment_id)
-            # Bills only
-            moves = payment.reconciled_bill_ids
-            all_tax_move = moves.mapped("tax_cash_basis_created_move_ids")
-            reversed_tax_ids = all_tax_move.filtered(
-                lambda tax_inv: tax_inv.reversed_entry_id
-            ).ids
-            linked_reversed_tax_ids = all_tax_move.mapped("reversed_entry_id").ids
-            tax_move = all_tax_move.filtered(
-                lambda tax_inv: tax_inv.id not in reversed_tax_ids
-                and tax_inv.id not in linked_reversed_tax_ids
-            )
-            if tax_move:
-                tax_move.mapped("line_ids").remove_move_reconcile()
-                tax_move.write({"name": "/", "state": "draft", "is_move_sent": False})
-        return res
-
 
 class AccountMove(models.Model):
     _inherit = "account.move"
@@ -665,3 +634,14 @@ class AccountMove(models.Model):
                 cert_vals.update({"income_tax_form": income_tax_form[0]})
             cert_list.append(cert_vals)
         return cert_list
+
+    @api.depends(
+        "posted_before", "state", "journal_id", "date", "move_type", "origin_payment_id"
+    )
+    def _compute_name(self):
+        if self.env.context.get("payment_id"):
+            for move in self:
+                if move.tax_cash_basis_origin_move_id:
+                    move.name = False
+            return
+        return super()._compute_name()

--- a/l10n_th_account_tax/models/account_partial_reconcile.py
+++ b/l10n_th_account_tax/models/account_partial_reconcile.py
@@ -7,6 +7,18 @@ from odoo import models
 class AccountPartialReconcile(models.Model):
     _inherit = "account.partial.reconcile"
 
+    def _get_move_type_cash_basis(self):
+        return ["in_invoice", "entry"]
+
+    def _update_state_cash_basis(self, moves):
+        """Back state tax cash basis in bills and entry to draft
+        not include net refund and payment. waiting clear tax later."""
+        move_type = self._get_move_type_cash_basis()
+        for move in moves:
+            if move.tax_cash_basis_origin_move_id.move_type in move_type:
+                move.mapped("line_ids").remove_move_reconcile()
+                move.write({"state": "draft", "is_move_sent": False})
+
     def _create_tax_cash_basis_moves(self):
         """This method is called from the move lines that
         create cash basis entry. We want to use the same payment_id when
@@ -53,4 +65,17 @@ class AccountPartialReconcile(models.Model):
                 "DELETE FROM account_move_line WHERE id in %s",
                 (tuple(del_move_lines.ids),),
             )
+
+        # Case: Vendor Bills only.
+        # Reset tax cash basis to draft. until clear tax or reset payment
+        # - Bill --> Payment
+        #     create cash basis (1) is draft
+        # - Payment (Posted) --> Payment (Draft)
+        #     create cash basis (2) and reconcile with (1) state change to posted
+        # - Bill manual reconcile payment
+        #     create cash basis (3) is draft
+        net_invoice_refund = self.env.context.get("net_invoice_refund")
+        net_invoice_payment = self.env.context.get("net_invoice_payment")
+        if not net_invoice_refund or net_invoice_payment:
+            self._update_state_cash_basis(moves)
         return moves

--- a/l10n_th_account_tax/tests/test_tax_invoice.py
+++ b/l10n_th_account_tax/tests/test_tax_invoice.py
@@ -330,6 +330,7 @@ class TestTaxInvoice(AccountTestInvoicingCommon):
             self.supplier_invoice_undue_vat.tax_cash_basis_created_move_ids
         )
         self.assertEqual(len(bill_tax_cash_basis), 1)
+        self.assertFalse(bill_tax_cash_basis.name)
         self.assertEqual(bill_tax_cash_basis.state, "draft")
         self.assertEqual(bill_tax_cash_basis.date, tax_date)
 
@@ -345,6 +346,7 @@ class TestTaxInvoice(AccountTestInvoicingCommon):
             self.supplier_invoice_undue_vat.tax_cash_basis_created_move_ids
         )
         self.assertEqual(len(bill_tax_cash_basis), 2)
+        self.assertNotIn("/", bill_tax_cash_basis.mapped("name"))
         self.assertEqual(list(set(bill_tax_cash_basis.mapped("state"))), ["posted"])
         self.assertFalse(
             any(list(set(bill_tax_cash_basis.line_ids.mapped("reconciled"))))
@@ -364,6 +366,8 @@ class TestTaxInvoice(AccountTestInvoicingCommon):
             self.supplier_invoice_undue_vat.tax_cash_basis_created_move_ids
         )
         self.assertEqual(len(bill_tax_cash_basis), 3)
+        new_caba = bill_tax_cash_basis.filtered(lambda tax: tax.state == "draft")
+        self.assertFalse(new_caba.name)
         self.assertEqual(
             len(list(set(bill_tax_cash_basis.mapped("state")))), 2
         )  # state draft and posted
@@ -390,6 +394,7 @@ class TestTaxInvoice(AccountTestInvoicingCommon):
             self.supplier_invoice_undue_vat.tax_cash_basis_created_move_ids
         )
         self.assertEqual(len(bill_tax_cash_basis), 3)
+        self.assertNotIn(False, bill_tax_cash_basis.mapped("name"))
         self.assertEqual(list(set(bill_tax_cash_basis.mapped("state"))), ["posted"])
         # Tax cash basis will change accounting date from clear tax
         date_object = fields.Date.from_string("2025-01-01")
@@ -423,6 +428,7 @@ class TestTaxInvoice(AccountTestInvoicingCommon):
             self.supplier_invoice_undue_vat_reconcile.tax_cash_basis_created_move_ids
         )
         self.assertEqual(len(bill_tax_cash_basis), 1)
+        self.assertFalse(bill_tax_cash_basis.name)
         self.assertEqual(bill_tax_cash_basis.state, "draft")
         # Test reset payment, tax cash basis in vendor bill must create 1 reversal
         # and reconciled
@@ -433,6 +439,7 @@ class TestTaxInvoice(AccountTestInvoicingCommon):
             self.supplier_invoice_undue_vat_reconcile.tax_cash_basis_created_move_ids
         )
         self.assertEqual(len(bill_tax_cash_basis), 2)
+        self.assertNotIn(False, bill_tax_cash_basis.mapped("name"))
         self.assertEqual(list(set(bill_tax_cash_basis.mapped("state"))), ["posted"])
         self.assertTrue(
             any(list(set(bill_tax_cash_basis.line_ids.mapped("reconciled"))))
@@ -453,6 +460,8 @@ class TestTaxInvoice(AccountTestInvoicingCommon):
             self.supplier_invoice_undue_vat_reconcile.tax_cash_basis_created_move_ids
         )
         self.assertEqual(len(bill_tax_cash_basis), 3)
+        new_caba = bill_tax_cash_basis.filtered(lambda tax: tax.state == "draft")
+        self.assertFalse(new_caba.name)
         self.assertEqual(
             len(list(set(bill_tax_cash_basis.mapped("state")))), 2
         )  # state draft and posted
@@ -481,6 +490,7 @@ class TestTaxInvoice(AccountTestInvoicingCommon):
             self.supplier_invoice_undue_vat_reconcile.tax_cash_basis_created_move_ids
         )
         self.assertEqual(len(bill_tax_cash_basis), 3)
+        self.assertNotIn(False, bill_tax_cash_basis.mapped("name"))
         self.assertEqual(list(set(bill_tax_cash_basis.mapped("state"))), ["posted"])
         # Check the move_line_ids, from both Bank and Cash Basis journal
         self.assertTrue(payment.move_id)
@@ -570,6 +580,7 @@ class TestTaxInvoice(AccountTestInvoicingCommon):
 
         caba = invoice.tax_cash_basis_created_move_ids
         self.assertEqual(len(caba), 1)
+        self.assertNotEqual(caba.name, False)
         self.assertEqual(caba.state, "posted")
 
         # Test unreconcile invoice and journal entry
@@ -579,6 +590,7 @@ class TestTaxInvoice(AccountTestInvoicingCommon):
         invoice.js_remove_outstanding_partial(partial_reconcile.id)
 
         self.assertEqual(len(invoice.tax_cash_basis_created_move_ids), 2)
+        self.assertNotIn(False, invoice.tax_cash_basis_created_move_ids.mapped("name"))
 
     def test_06_supplier_invoice_refund_reconcile(self):
         """Case on undue vat, to net refund with vendor bill.


### PR DESCRIPTION
Create cash basis without sequence. It will create after clear tax