### PR TITLE
[18.0][ADD] l10n_th_amount_to_text: pre_init_hook install Thai language

### DIFF
--- a/l10n_th_amount_to_text/README.rst
+++ b/l10n_th_amount_to_text/README.rst
@@ -35,10 +35,11 @@ results for Thai.
 
 **Example:**
 
-- Amount: 45.75 Baht
+-  Amount: 45.75 Baht
 
-  - User Language: **Thai** → สี่สิบห้า Baht และ เจ็ดสิบห้า Satang
-  - User Language: **English** → Forty-Five Baht and Seventy-Five Satang
+   -  User Language: **Thai** → สี่สิบห้า Baht และ เจ็ดสิบห้า Satang
+   -  User Language: **English** → Forty-Five Baht and Seventy-Five
+      Satang
 
 These results are inaccurate for Thai language formatting. This module
 provides a base for accurately converting numbers to Thai text.
@@ -71,14 +72,14 @@ Example Usage:
 
 **Results Based on Context:**
 
-- When ``lang=th_TH`` context is sent:
+-  When ``lang=th_TH`` context is sent:
 
-  - Currency: **THB** → ``สี่สิบห้าบาทเจ็ดสิบห้าสตางค์``
-  - Currency: **EUR** → ``สี่สิบห้ายูโรเจ็ดสิบห้าเซนต์``
-  - Currency: **USD** → ``สี่สิบห้าดอลลาร์เจ็ดสิบห้าเซนต์``
+   -  Currency: **THB** → ``สี่สิบห้าบาทเจ็ดสิบห้าสตางค์``
+   -  Currency: **EUR** → ``สี่สิบห้ายูโรเจ็ดสิบห้าเซนต์``
+   -  Currency: **USD** → ``สี่สิบห้าดอลลาร์เจ็ดสิบห้าเซนต์``
 
-- When no context is sent: Odoo's default logic will handle the
-  conversion.
+-  When no context is sent: Odoo's default logic will handle the
+   conversion.
 
 **Important Notes:**
 
@@ -110,10 +111,10 @@ Authors
 Contributors
 ------------
 
-- `Ecosoft <http://ecosoft.co.th>`__:
+-  `Ecosoft <http://ecosoft.co.th>`__:
 
-  - Saran Lim. <saranl@ecosoft.co.th>
-  - Pimolnat Suntian <pimolnats@ecosoft.co.th>
+   -  Saran Lim. <saranl@ecosoft.co.th>
+   -  Pimolnat Suntian <pimolnats@ecosoft.co.th>
 
 Maintainers
 -----------

--- a/l10n_th_amount_to_text/__init__.py
+++ b/l10n_th_amount_to_text/__init__.py
@@ -1,3 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from . import models
+from .hooks import pre_init_hook

--- a/l10n_th_amount_to_text/__manifest__.py
+++ b/l10n_th_amount_to_text/__manifest__.py
@@ -12,6 +12,7 @@
     "depends": ["base"],
     "data": [],
     "installable": True,
+    "pre_init_hook": "pre_init_hook",
     "development_status": "Beta",
     "maintainers": ["Saran440"],
 }

--- a/l10n_th_amount_to_text/hooks.py
+++ b/l10n_th_amount_to_text/hooks.py
@@ -1,0 +1,21 @@
+# Copyright 2025 Ecosoft Co., Ltd. (http://ecosoft.co.th)
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def pre_init_hook(env):
+    """Activate Thai language for use in amount_to_text"""
+    th_lang = (
+        env["res.lang"]
+        .sudo()
+        .search([("code", "=", "th_TH"), ("active", "=", False)], limit=1)
+    )
+
+    if th_lang:
+        th_lang.write({"active": True})
+        _logger.info(f"Activated Thai language: {th_lang.code}")
+    else:
+        _logger.info("Thai language (th_TH) not found in res.lang!")

--- a/l10n_th_amount_to_text/static/description/index.html
+++ b/l10n_th_amount_to_text/static/description/index.html
@@ -378,7 +378,8 @@ results for Thai.</p>
 <ul class="simple">
 <li>Amount: 45.75 Baht<ul>
 <li>User Language: <strong>Thai</strong> → สี่สิบห้า Baht และ เจ็ดสิบห้า Satang</li>
-<li>User Language: <strong>English</strong> → Forty-Five Baht and Seventy-Five Satang</li>
+<li>User Language: <strong>English</strong> → Forty-Five Baht and Seventy-Five
+Satang</li>
 </ul>
 </li>
 </ul>

--- a/l10n_th_amount_to_text/tests/test_amount_to_text.py
+++ b/l10n_th_amount_to_text/tests/test_amount_to_text.py
@@ -1,14 +1,16 @@
 # Copyright 2020 Ecosoft Co., Ltd (http://ecosoft.co.th/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
-from odoo.exceptions import UserError
 from odoo.tests.common import TransactionCase
+
+from .. import pre_init_hook
 
 
 class TestAmountToText(TransactionCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+        cls.th_lang = cls.env.ref("base.lang_th")
 
     def test_01_currency_th_amount_to_text(self):
         """verify that amount_to_text converted text to thai language"""
@@ -29,11 +31,15 @@ class TestAmountToText(TransactionCase):
         self.assertEqual(
             amount_text_eur, "One Thousand And Fifty Euros and Seventy-Five Cents"
         )
-        # Test with other currency, Thai language.
-        # If not activated thai language, it should error.
-        with self.assertRaises(UserError):
-            amount_text_eur = currency.with_context(lang="th_TH").amount_to_text(amount)
-        # Activate Thai language
-        self.env.ref("base.lang_th").write({"active": True})
         amount_text_eur = currency.with_context(lang="th_TH").amount_to_text(amount)
         self.assertEqual(amount_text_eur, "หนึ่งพันห้าสิบยูโรเจ็ดสิบห้าเซนต์")
+
+    def test_03_pre_init_hook(self):
+        """If not activate Thai Language. It will auto activate."""
+        self.th_lang.write({"active": False})
+        self.assertFalse(self.th_lang.active)
+        pre_init_hook(self.env)
+        self.assertTrue(self.th_lang.active)
+        # Nothing to do
+        pre_init_hook(self.env)
+        self.assertTrue(self.th_lang.active)


### PR DESCRIPTION
To use this module. you need to activate Thai language.
So, I added pre-init-hook to activated Thai language when install this module.