### PR TITLE
[18.0][IMP] l10n_th_account_tax: add verify_by on wht for tracking

### DIFF
--- a/l10n_th_account_tax/models/withholding_tax_cert.py
+++ b/l10n_th_account_tax/models/withholding_tax_cert.py
@@ -171,6 +171,11 @@ class WithholdingTaxCert(models.Model):
         copy=False,
         tracking=True,
     )
+    verify_by = fields.Many2one(
+        comodel_name="res.users",
+        copy=False,
+        tracking=True,
+    )
 
     @api.depends("payment_id", "move_id")
     def _compute_wht_cert_data(self):
@@ -179,13 +184,18 @@ class WithholdingTaxCert(models.Model):
             rec.date = rec.payment_id.date or rec.move_id.date or rec.date
 
     def action_draft(self):
-        return self.write({"state": "draft"})
+        return self.write(
+            {
+                "verify_by": False,
+                "state": "draft",
+            }
+        )
 
     def action_done(self):
         sequence_model = self.env["ir.sequence"]
         for rec in self:
             # Update sequence WHT
-            if rec.number in [False, "/"]:
+            if rec.number == "/":
                 rec.number = sequence_model.next_by_code("withholding.tax.cert")
 
             if rec.ref_wht_cert_id:
@@ -193,11 +203,16 @@ class WithholdingTaxCert(models.Model):
                 rec.ref_wht_cert_id.message_post(
                     body=self.env._("This document was substituted by %s.") % rec.name
                 )
-        self.write({"state": "done"})
+        self.write({"verify_by": self.env.user.id, "state": "done"})
         return True
 
     def action_cancel(self):
-        self.write({"state": "cancel"})
+        self.write(
+            {
+                "verify_by": False,
+                "state": "cancel",
+            }
+        )
         return True
 
     @api.onchange("income_tax_form")

--- a/l10n_th_account_tax/tests/test_withholding_tax.py
+++ b/l10n_th_account_tax/tests/test_withholding_tax.py
@@ -245,20 +245,25 @@ class TestWithholdingTax(AccountTestInvoicingCommon):
         self.assertEqual(
             cert_line.wht_cert_income_desc, "2. ค่าธรรมเนียม ค่านายหน้า ฯลฯ 40(2)"
         )
+        self.assertFalse(cert.verify_by)
 
         cert.action_done()
         self.assertEqual(cert.state, "done")
         self.assertNotEqual(cert.number, "/")
+        self.assertEqual(cert.verify_by, self.env.user)
+
         # WHT Cert created and done, wht cert status should change to done
         self.assertEqual(payment.wht_cert_status, "done")
         # After done, can draft withholding tax
         cert.action_draft()
         self.assertEqual(cert.state, "draft")
         self.assertNotEqual(cert.number, "/")
+        self.assertFalse(cert.verify_by)
         # WHT Cert cancel, wht cert status should change to cancel
         cert.action_cancel()
         self.assertEqual(cert.state, "cancel")
         self.assertEqual(payment.wht_cert_status, "cancel")
+        self.assertFalse(cert.verify_by)
 
     def test_02_create_payment_withholding_tax_product(self):
         """Create payment with withholding tax from product"""

--- a/l10n_th_account_tax/views/withholding_tax_cert.xml
+++ b/l10n_th_account_tax/views/withholding_tax_cert.xml
@@ -64,6 +64,7 @@
                             <field name="company_id" invisible="1" readonly="1" />
                             <field name="currency_id" invisible="1" />
                             <field name="ref_wht_cert_id" readonly="state != 'draft'" />
+                            <field name="verify_by" readonly="1" />
                             <field name="date" readonly="state != 'draft'" />
                         </group>
                     </group>


### PR DESCRIPTION
Add new field `verify_by` on WHT Certificates.
It will stamp when document is done and clear when reset or cancel
<img width="1503" height="634" alt="Selection_014" src="https://github.com/user-attachments/assets/4b9a58d2-e895-4edb-ace8-72c217005f43" />
