### PR TITLE
[15.0][FIX] l10n_th_account_tax: handle PIT below taxable threshold

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -317,11 +317,11 @@ class AccountMove(models.Model):
 
     def _compute_has_wht(self):
         """Has WHT when
-        1. Has wht_tax_id
+        1. Has wht_move_ids
         2. Is not invoice (move_type == 'entry')
         """
         for rec in self:
-            wht_tax = True if rec.line_ids.mapped("wht_tax_id") else False
+            wht_tax = bool(rec.wht_move_ids)
             not_inv = rec.move_type == "entry"
             rec.has_wht = wht_tax and not_inv
 

--- a/l10n_th_account_tax/views/account_payment_view.xml
+++ b/l10n_th_account_tax/views/account_payment_view.xml
@@ -154,4 +154,19 @@
             </group>
         </field>
     </record>
+    <record id="view_account_payment_search" model="ir.ui.view">
+        <field name="name">account.payment.search</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_search" />
+        <field name="arch" type="xml">
+            <xpath expr="//filter[@name='date']" position="before">
+                <filter
+                    name="wht_not_created"
+                    string="WHT Not yet created"
+                    domain="[('wht_cert_ids', '=', False), ('wht_move_ids', '!=', False)]"
+                />
+                <separator />
+            </xpath>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
1. Allow create WHT (PIT) if it below taxable threshold.
Normally, we need to add WHT manual.

2. Add filter WHT Not yet created in payment view. for user find WHT is not created

<img width="205" height="437" alt="Selection_024" src="https://github.com/user-attachments/assets/de87d4a9-ca2b-4cb6-beee-f1462eed5f4a" />
