### PR TITLE
[15.0][FIX] l10n_th_gov_hr_expense: compute clearing date due only advance

### DIFF
--- a/l10n_th_gov_hr_expense/models/hr_expense.py
+++ b/l10n_th_gov_hr_expense/models/hr_expense.py
@@ -105,6 +105,8 @@ class HrExpenseSheet(models.Model):
         """
         for sheet in self:
             sheet.clearing_date_due = False
+            if not sheet.advance:
+                continue
             if sheet.clearing_term == "thirty_days_after_return" and sheet.date_return:
                 sheet.clearing_date_due = sheet.date_return + relativedelta(days=29)
             elif (


### PR DESCRIPTION
Update the clearing date due upon posting journal entries, only for expenses that are advances.