### PR TITLE
[15.0][FIX] l10n_th_gov_account_asset_management: error when remove asset

### DIFF
--- a/l10n_th_gov_account_asset_management/wizard/account_asset_remove.py
+++ b/l10n_th_gov_account_asset_management/wizard/account_asset_remove.py
@@ -22,7 +22,14 @@ class AccountAssetRemove(models.TransientModel):
                 if res["res_model"] == "account.move":
                     moves = self.env["account.move"].search(res["domain"])
         for move in moves:
-            move.write({"ref": ", ".join(move.line_ids.mapped("asset_id.number"))})
+            # Filter out asset is not number
+            asset_numbers = {
+                num for num in move.line_ids.mapped("asset_id.number") if num
+            }
+            if not asset_numbers:
+                continue
+
+            move.write({"ref": ", ".join(asset_numbers)})
         return res
 
     def remove_multi_assets(self):
@@ -30,7 +37,7 @@ class AccountAssetRemove(models.TransientModel):
         assets = self.env["account.asset"].browse(asset_ids)
         ctx = dict(self.env.context)
         for asset in assets:
-            if (
+            if asset.state != "close" and (
                 asset.method in ["linear-limit", "degr-limit"]
                 and asset.value_residual != asset.salvage_value
                 or asset.value_residual


### PR DESCRIPTION
Error 2 case, when remove asset
1. Can't Remove asset if no asset number
2. Remove asset from bill, it will compute with `early_removal`
<img width="1976" height="1019" alt="Selection_007" src="https://github.com/user-attachments/assets/054818bf-27f6-41bf-985e-89246f7f5d37" />
