### PR TITLE
[15.0][IMP] currency_rate_update_TH_BOT: Update BOT API

### DIFF
--- a/currency_rate_update_TH_BOT/data/config_parameter.xml
+++ b/currency_rate_update_TH_BOT/data/config_parameter.xml
@@ -2,10 +2,10 @@
 <odoo noupdate="1">
     <record id="hostname_th_bot" model="ir.config_parameter">
         <field name="key">hostname_TH_BOT</field>
-        <field name="value">https://apigw1.bot.or.th</field>
+        <field name="value">https://gateway.api.bot.or.th</field>
     </record>
     <record id="route_th_bot_exchange_daily" model="ir.config_parameter">
         <field name="key">route_TH_BOT_exchange_daily</field>
-        <field name="value">/bot/public/Stat-ExchangeRate/v2/DAILY_AVG_EXG_RATE</field>
+        <field name="value">/Stat-ExchangeRate/v2/DAILY_AVG_EXG_RATE</field>
     </record>
 </odoo>

--- a/currency_rate_update_TH_BOT/models/res_company.py
+++ b/currency_rate_update_TH_BOT/models/res_company.py
@@ -7,4 +7,4 @@ from odoo import fields, models
 class ResCompany(models.Model):
     _inherit = "res.company"
 
-    bot_client_id = fields.Char(string="BOT Client ID")
+    bot_token = fields.Char(string="BOT Token")

--- a/currency_rate_update_TH_BOT/models/res_config_settings.py
+++ b/currency_rate_update_TH_BOT/models/res_config_settings.py
@@ -7,8 +7,8 @@ from odoo import fields, models
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
-    bot_client_id = fields.Char(
-        string="Client ID",
-        related="company_id.bot_client_id",
+    bot_token = fields.Char(
+        string="BOT Token",
+        related="company_id.bot_token",
         readonly=False,
     )

--- a/currency_rate_update_TH_BOT/models/res_currency_rate_provider_BOT.py
+++ b/currency_rate_update_TH_BOT/models/res_currency_rate_provider_BOT.py
@@ -139,25 +139,29 @@ class ResCurrencyRateProviderBOT(models.Model):
                     )
                 )
             ICP = self.env["ir.config_parameter"].sudo()
-            bot_client_id = self.company_id.bot_client_id
-            if not bot_client_id:
+            bot_token = self.company_id.bot_token
+            if not bot_token:
                 raise UserError(_("No bot.or.th credentials specified!"))
             hostname = ICP.get_param("hostname_TH_BOT")
             route_BOT = ICP.get_param("route_TH_BOT_exchange_daily")
-            url = "{}{}/?start_period={}&end_period={}".format(
+            default_url = "{}{}/?start_period={}&end_period={}".format(
                 hostname,
                 route_BOT,
                 date_from.strftime("%Y-%m-%d"),
                 date_to.strftime("%Y-%m-%d"),
             )
-            headers = {"X-IBM-Client-Id": bot_client_id, "accept": "application/json"}
+            headers = {
+                "Authorization": bot_token,
+                "accept": "application/json",
+                "Content-Type": "application/json",
+            }
             bot_currencies = self.env["res.currency"].search(
                 [("name", "in", currencies)]
             )
             content = dict()
             for bot_currency in bot_currencies:
                 currency = bot_currency.bot_currency_name
-                url = "{}&currency={}".format(url, currency)
+                url = "{}&currency={}".format(default_url, currency)
                 response = requests.get(url, headers=headers)
                 data_dict = response.json()
                 result = data_dict.get("result", False)

--- a/currency_rate_update_TH_BOT/tests/test_currency_rate_update_TH_BOT.py
+++ b/currency_rate_update_TH_BOT/tests/test_currency_rate_update_TH_BOT.py
@@ -67,12 +67,12 @@ class TestResCurrencyRateProviderBOT(common.TransactionCase):
         self.none_provider._update(date, date)
 
     def test_03_update_no_clien_id(self):
-        self.my_company.bot_client_id = False
+        self.my_company.bot_token = False
         date = self.today - relativedelta(days=1)
         self.bot_provider._update(date, date)
 
     def test_04_update_clien_id_fail(self):
-        self.my_company.bot_client_id = "Test"
+        self.my_company.bot_token = "Test"
         date = self.today - relativedelta(days=1)
         self.bot_provider._update(date, date)
 

--- a/currency_rate_update_TH_BOT/views/res_config_settings.xml
+++ b/currency_rate_update_TH_BOT/views/res_config_settings.xml
@@ -25,11 +25,8 @@
                         </div>
                         <div class="content-group">
                             <div class="row mt16">
-                                <label
-                                    for="bot_client_id"
-                                    class="col-lg-3 o_light_label"
-                                />
-                                <field name="bot_client_id" />
+                                <label for="bot_token" class="col-lg-3 o_light_label" />
+                                <field name="bot_token" />
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
On `ras_currency_rate_provider_BOT.py: line 147`

If you do not use default_url, if there are many currency to call api, each time the URL will be like this:
For example we have 2 currency like EUR, JPY

- 1st call: `../start_period=2025-10-08&end_period=2025-10-08&currency=EUR`
- 2nd call: `../start_period=2025-10-08&end_period=2025-10-08&currency=EUR&currency=JPY`


but on 2nd call it return rate of EUR not JPY
Note: on old version it correctly return Rate of JPY.