### PR TITLE
[15.0][FIX] l10n_th_bank_payment_export: export raw file don't escape

### DIFF
--- a/l10n_th_bank_payment_export/templates/report_template.xml
+++ b/l10n_th_bank_payment_export/templates/report_template.xml
@@ -2,6 +2,6 @@
 <odoo>
     <!-- Format Text File should start at line1, Don't change it -->
     <template id="bank_payment_export_text_file"><t
-            t-out="docs._export_bank_payment_text_file()"
+            t-raw="docs._export_bank_payment_text_file()"
         /></template>
 </odoo>


### PR DESCRIPTION
Replaced t-out with t-raw to prevent HTML escaping.
The previous implementation was converting characters like & into &amp;, which caused incorrect display in the generated file.
t-raw allows the value to render as-is, which is required for the bank file text format.

```
value = 'A & B'
use t-out =>  'A &amp; B'
use t-raw => 'A & B'
```