### PR TITLE
[18.0][FIX] l10n_th_partner: fix xpath on setting view

### DIFF
--- a/l10n_th_account_tax/tests/test_withholding_tax.py
+++ b/l10n_th_account_tax/tests/test_withholding_tax.py
@@ -205,7 +205,7 @@ class TestWithholdingTax(AccountTestInvoicingCommon):
         self.assertEqual(register_payment.writeoff_label, "Withholding Tax 3%")
         action_payment = register_payment.action_create_payments()
         payment = self.env[action_payment["res_model"]].browse(action_payment["res_id"])
-        self.assertEqual(payment.state, "paid")
+        self.assertEqual(payment.state, "in_process")
         self.assertEqual(payment.amount, price_unit * 0.97)
         self.assertFalse(payment.wht_certs_count)
         # Allow create WHT Cert, but not yet
@@ -301,7 +301,7 @@ class TestWithholdingTax(AccountTestInvoicingCommon):
         payment_id = self.env[action_payment["res_model"]].browse(
             action_payment["res_id"]
         )
-        self.assertEqual(payment_id.state, "paid")
+        self.assertEqual(payment_id.state, "in_process")
         self.assertEqual(payment_id.amount, price_unit * 0.97)
 
     def test_03_withholding_tax_customer_invoice(self):
@@ -404,7 +404,7 @@ class TestWithholdingTax(AccountTestInvoicingCommon):
         self.assertEqual(register_payment.writeoff_label, "Withholding Tax 3%")
         action_payment = register_payment.action_create_payments()
         payment = self.env[action_payment["res_model"]].browse(action_payment["res_id"])
-        self.assertEqual(payment.state, "paid")
+        self.assertEqual(payment.state, "in_process")
         self.assertEqual(payment.amount, 2 * price_unit * 0.97)
 
     def test_05_create_wht_cert_journal(self):

--- a/l10n_th_partner/tests/test_l10n_th_partner.py
+++ b/l10n_th_partner/tests/test_l10n_th_partner.py
@@ -30,7 +30,6 @@ class TestL10nThPartner(TransactionCase):
         """Test that you change title"""
         self.assertEqual(self.user.name, "Firstname Lastname")
         self.user.title = self.title
-        self.user._compute_name()
         self.assertEqual(self.user.name, "Miss Firstname Lastname")
 
     def test_res_partner(self):

--- a/l10n_th_partner/views/res_config_settings_views.xml
+++ b/l10n_th_partner/views/res_config_settings_views.xml
@@ -11,7 +11,7 @@
         />
         <field name="arch" type="xml">
             <xpath
-                expr="//block[@name='partner_names_order_setting_container']"
+                expr="//block[@name='partner_names_setting_container']"
                 position="inside"
             >
                 <setting


### PR DESCRIPTION
Related to this change: https://github.com/OCA/partner-contact/commit/87976b9d835161e0e1086a5a20d697eae9ac6c6c#diff-32689e8add44a26136c1c8c886acfe2b3247b800170927d2cde87b1bbc42756aR8

<img width="1070" height="479" alt="image" src="https://github.com/user-attachments/assets/c5e55a1c-b62a-4e28-906c-753bdf18261f" />

So we have to fix path on res_config_settings_views.xml too.