### PR TITLE
[18.0][IMP] l10n_account_tax: label wht_tax_id not show

### DIFF
--- a/l10n_th_account_tax/views/product_view.xml
+++ b/l10n_th_account_tax/views/product_view.xml
@@ -5,7 +5,7 @@
         <field name="model">product.template</field>
         <field name="inherit_id" ref="product.product_template_form_view" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='taxes_id']" position="after">
+            <xpath expr="//div[@name='taxes_div']" position="after">
                 <field name="wht_tax_id" />
             </xpath>
             <xpath expr="//field[@name='supplier_taxes_id']" position="after">


### PR DESCRIPTION
**Issue:**
The label of `wht_tax_id` is not displayed correctly. Currently it displayed in same in line Sales Taxes but correctly it should be displayed after the Sales Taxes.
<img width="1470" height="796" alt="SCR-20251225-kpis" src="https://github.com/user-attachments/assets/237a53e2-b61c-476e-9b9c-cb888c5a0411" />

**Cause:**
In Odoo version 17, the `taxes_id` field in the account module was rendered using only a `<field>` tag.
In Odoo version 18, `taxes_id` is wrapped with a `<label>` and a `<div>`.
This additional structure causes the `wht_tax_id` field to appear on the same line instead of below the Sales Taxes section.
<img width="1469" height="787" alt="SCR-20251225-kpbb" src="https://github.com/user-attachments/assets/08418d57-1eb1-46ef-9bf4-59ad0300f4fb" />
