### PR TITLE
[18.0][FIX] l10n_th_account_tax: delete line undue with unlink()

### DIFF
--- a/l10n_th_account_tax/models/account_partial_reconcile.py
+++ b/l10n_th_account_tax/models/account_partial_reconcile.py
@@ -62,10 +62,7 @@ class AccountPartialReconcile(models.Model):
             and not line.reconciled
         )
         if del_move_lines:
-            self.env.cr.execute(
-                "DELETE FROM account_move_line WHERE id in %s",
-                (tuple(del_move_lines.ids),),
-            )
+            del_move_lines.with_context(force_delete=1, dynamic_unlink=1).unlink()
 
         # Case: Vendor Bills only.
         # Reset tax cash basis to draft. until clear tax or reset payment


### PR DESCRIPTION
Change deletes line cash basis with unlink() instead of sql because it will effect with other module

Step to test:
1. Install module `l10n_th_account_tax `and `account_financial_report`
2. Config with undue tax and Analytic Distribution
3. Create Customer Invoice with Undue
4. Pay > Create Payment

It error

```
The operation cannot be completed: another model requires the record being deleted. If possible, archive it instead.

Model: Unknown (unknown)
Constraint: account_analytic_account_account_move_account_move_line_id_fkey
```

from code in module account_financial_report https://github.com/OCA/account-financial-reporting/blob/18.0/account_financial_report/models/account_move_line.py#L17

```
    @api.depends("analytic_distribution")
    def _compute_analytic_account_ids(self):
        # Prefetch all involved analytic accounts
        batch_by_analytic_account = defaultdict(lambda: self.env["account.move.line"])
        for record in self.filtered("analytic_distribution"):
            # NB: ``analytic_distribution`` is a JSON field where keys can be either
            # 'account.id' or 'account.id,account.id'
            # Eg: https://github.com/odoo/odoo/blob/8479b4e/addons/sale/models/account_move_line.py#L158
            for key in record.analytic_distribution:
                for account_id in map(int, key.split(",")):
                    batch_by_analytic_account[account_id] += record
        existing_account_ids = set(
            self.env["account.analytic.account"]
            .browse(batch_by_analytic_account)
            .exists()
            .ids
        )
        # Store them
        self.analytic_account_ids = [Command.clear()]
        for account_id, records in batch_by_analytic_account.items():
            if account_id in existing_account_ids:
                records.analytic_account_ids = [Command.link(account_id)]

```

So, I think we should delete with standard is safe and clean