### PR TITLE
[15.0][FIX] l10n_th_account_tax: fix wht table disappear

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -465,6 +465,7 @@ class AccountMove(models.Model):
         # - Create account.withholding.move, for every withholding tax line
         # - For case PIT, it is possible that there is no withholidng amount
         #   but still need to keep track the withholding.move base amount
+        AccountMove = self.env["account.move"]
         for move in self:
             # Normal case, create withholding.move only when withholding
             wht_moves = move.line_ids.filtered("account_id.wht_account")
@@ -475,18 +476,21 @@ class AccountMove(models.Model):
             move.write({"wht_move_ids": [(5, 0, 0)] + withholding_moves})
             # On payment JE, keep track of move when PIT not withheld, use data from vendor bill
             if move.payment_id and not move.payment_id.wht_move_ids.mapped("is_pit"):
+                bills = AccountMove
                 if self.env.context.get("active_model") == "account.move":
-                    bills = self.env["account.move"].browse(
-                        self.env.context.get("active_ids", [])
-                    )
-                    bill_wht_lines = bills.mapped("line_ids").filtered(
-                        "wht_tax_id.is_pit"
-                    )
-                    bill_wht_moves = [
-                        (0, 0, self._prepare_withholding_move(bill_wht_move))
-                        for bill_wht_move in bill_wht_lines
-                    ]
-                    move.write({"wht_move_ids": bill_wht_moves})
+                    bills = AccountMove.browse(self.env.context.get("active_ids", []))
+                elif move.payment_id.original_move_ids:
+                    bills = move.payment_id.original_move_ids
+                if not bills:
+                    continue
+
+                bill_wht_lines = bills.mapped("line_ids").filtered("wht_tax_id.is_pit")
+                bill_wht_moves = [
+                    (0, 0, self._prepare_withholding_move(bill_wht_move))
+                    for bill_wht_move in bill_wht_lines
+                ]
+                move.write({"wht_move_ids": bill_wht_moves})
+
         # When post, do remove the existing certs
         self.mapped("wht_cert_ids").unlink()
         return res

--- a/l10n_th_account_tax/models/account_payment.py
+++ b/l10n_th_account_tax/models/account_payment.py
@@ -50,6 +50,10 @@ class AccountPayment(models.Model):
         string="# Withholding Tax Certs",
         compute="_compute_wht_certs_count",
     )
+    # NOTE: Add this field for keep original invoices only, Used in V15
+    original_move_ids = fields.Many2many(
+        comodel_name="account.move",
+    )
 
     @api.depends("wht_cert_ids")
     def _compute_wht_certs_count(self):

--- a/l10n_th_account_tax/views/account_payment_view.xml
+++ b/l10n_th_account_tax/views/account_payment_view.xml
@@ -75,6 +75,9 @@
                     />
                 </div>
             </xpath>
+            <xpath expr="//field[@name='partner_bank_id']" position="after">
+                <field name="original_move_ids" widget="many2many_tags" />
+            </xpath>
             <button name="action_post" position="after">
                 <field name="to_clear_tax" invisible="1" />
                 <button

--- a/l10n_th_account_tax/wizard/account_payment_register.py
+++ b/l10n_th_account_tax/wizard/account_payment_register.py
@@ -73,11 +73,17 @@ class AccountPaymentRegister(models.TransientModel):
 
     def _create_payment_vals_from_wizard(self):
         payment_vals = super()._create_payment_vals_from_wizard()
+        payment_vals["original_move_ids"] = self.line_ids.mapped("move_id").ids
         # Check case auto and manual withholding tax
         if self.payment_difference_handling == "reconcile" and self.wht_tax_id:
             payment_vals["write_off_line_vals"] = self._prepare_writeoff_move_line(
                 payment_vals.get("write_off_line_vals", False)
             )
+        return payment_vals
+
+    def _create_payment_vals_from_batch(self, batch_result):
+        payment_vals = super()._create_payment_vals_from_batch()
+        payment_vals["original_move_ids"] = self.line_ids.mapped("move_id").ids
         return payment_vals
 
     @api.depends(


### PR DESCRIPTION
Step to test:
1. Configure WHT
2. Create a vendor bill and select WHT, then register the payment
3. It creates a payment with WHT applied
4. Reset the payment to draft and confirm the payment again
5. The WHT table disappears

This PR fixes the issue by adding a new field, `original_move_ids`, to preserve the origin documents related to the payment.