### PR TITLE
[18.0][FIX] l10n_th_account_tax_report: order data by row number

### DIFF
--- a/l10n_th_account_tax_report/reports/tax_report.py
+++ b/l10n_th_account_tax_report/reports/tax_report.py
@@ -81,7 +81,7 @@ class ThaiTaxReport(models.AbstractModel):
                 AND t.reversed_id is null
             ) a
             GROUP BY {self._query_groupby_tax()}
-            ORDER BY tax_date, tax_invoice_number
+            ORDER BY row_number, tax_date, tax_invoice_number
         """,
             (
                 tax_id,


### PR DESCRIPTION
Order data by row number

Fix case: Late Tax Invoice reporting causes rows to be out of order and prevents the monthly total from being displayed

Example: Row 2 is shown as the last row

<img width="2816" height="274" alt="image" src="https://github.com/user-attachments/assets/d07fff6a-a891-42e0-87af-8d584a3f3b63" />

After the fix, the rows will be sorted in the correct order as expected

<img width="2714" height="332" alt="image" src="https://github.com/user-attachments/assets/5d8100c2-056e-4185-9ead-3990e9218881" />

