### PR TITLE
[18.0][IMP] l10n_th_account_tax_report: groupby tax

### DIFF
--- a/l10n_th_account_tax_report/reports/tax_report.py
+++ b/l10n_th_account_tax_report/reports/tax_report.py
@@ -10,11 +10,17 @@ class ThaiTaxReport(models.AbstractModel):
     _description = "Thai Tax Report"
 
     def _query_select_tax(self):
+        # `name` is aggregated (not grouped) so that several documents sharing
+        # the same tax_invoice_number collapse into a single report line. This
+        # covers cash-basis purchases where one vendor tax invoice is issued for
+        # a group payment of multiple bills. Sales numbers come from a sequence
+        # (unique per line) so they never merge unintentionally.
         return """
             ROW_NUMBER() OVER (ORDER BY tax_date, tax_invoice_number) AS row_number,
             company_id, account_id, partner_id, tax_invoice_number,
             TO_CHAR(tax_date, 'DD/MM/YYYY') AS tax_date,
-            name, sum(tax_base_amount) tax_base_amount,
+            string_agg(DISTINCT name, ', ' ORDER BY name) AS name,
+            sum(tax_base_amount) tax_base_amount,
             sum(tax_amount) tax_amount
         """
 
@@ -41,7 +47,7 @@ class ThaiTaxReport(models.AbstractModel):
         """
 
     def _query_groupby_tax(self):
-        return "company_id, account_id, partner_id, tax_invoice_number, tax_date, name"
+        return "company_id, account_id, partner_id, tax_invoice_number, tax_date"
 
     def _domain_where_clause_tax(self, show_cancel):
         condition = "IN ('posted', 'cancel')" if show_cancel else "= 'posted'"

--- a/l10n_th_account_tax_report/tests/test_tax_report.py
+++ b/l10n_th_account_tax_report/tests/test_tax_report.py
@@ -73,6 +73,12 @@ class TestTaxReport(AccountTestInvoicingCommon):
             }
         )
 
+    def _get_purchase_report_lines(self):
+        self.env.flush_all()
+        report = self.env["report.l10n_th_account_tax_report.report_thai_tax"]
+        res_data = report._get_report_values(self.tax_purchase_report_wizard.ids, {})
+        return res_data["tax_report_data"]
+
     @freeze_time("2001-01-01")
     def _create_date_range(self):
         RangeType = self.env["date.range.type"]
@@ -222,3 +228,62 @@ class TestTaxReport(AccountTestInvoicingCommon):
         model.create_xlsx_report(
             self.tax_purchase_report_wizard.ids, data=report["data"]
         )
+
+    @freeze_time("2001-01-01")
+    def test_06_merge_same_tax_invoice_number(self):
+        """Two bills sharing one vendor tax invoice number collapse to a single
+        report line with summed base and tax. This is the group-payment case
+        where one vendor tax invoice covers multiple bills."""
+        bill1 = self.bill
+
+        bill2 = self.init_invoice(
+            move_type="in_invoice",
+            partner=self.env.ref("base.res_partner_1"),
+            invoice_date=self.date_range.date_end,
+            products=self.env.ref("product.product_product_7"),
+            amounts=[100.0],
+            taxes=self.tax_purchase_a,
+        )
+        bill2.tax_invoice_ids.write(
+            {
+                "tax_invoice_number": "TEST",
+                "tax_invoice_date": self.date_range.date_end,
+            }
+        )
+        bill2.action_post()
+
+        lines = [
+            line
+            for line in self._get_purchase_report_lines()
+            if line["tax_invoice_number"] == "TEST"
+        ]
+        self.assertEqual(len(lines), 1)
+        tax_invoices = (bill1 + bill2).tax_invoice_ids
+        self.assertEqual(
+            lines[0]["tax_base_amount"],
+            sum(tax_invoices.mapped("tax_base_amount")),
+        )
+        self.assertEqual(lines[0]["tax_amount"], sum(tax_invoices.mapped("balance")))
+
+    @freeze_time("2001-01-01")
+    def test_07_distinct_tax_invoice_numbers_not_merged(self):
+        """Different vendor tax invoice numbers stay as separate report lines."""
+        bill2 = self.init_invoice(
+            move_type="in_invoice",
+            partner=self.env.ref("base.res_partner_1"),
+            invoice_date=self.date_range.date_end,
+            products=self.env.ref("product.product_product_7"),
+            amounts=[100.0],
+            taxes=self.tax_purchase_a,
+        )
+        bill2.tax_invoice_ids.write(
+            {
+                "tax_invoice_number": "TEST222",
+                "tax_invoice_date": self.date_range.date_end,
+            }
+        )
+        bill2.action_post()
+        numbers = [
+            line["tax_invoice_number"] for line in self._get_purchase_report_lines()
+        ]
+        self.assertEqual(len([n for n in numbers if n in ("TEST", "TEST222")]), 2)


### PR DESCRIPTION
Step to test:

1. Create 2 invoices with undue VAT.
2. Register a grouped payment for both invoices.
3. Generate the tax invoice report.

Expected result:

- The payment contains 2 tax invoice lines.
- If the tax lines have the same Tax Name and Tax Date, the report should display them as a single line instead of duplicating them.
<img width="2484" height="335" alt="selection_287" src="https://github.com/user-attachments/assets/23d4d1be-387f-4dcb-8161-e1c70ea5de24" />
