### PR TITLE
[18.0][FIX] l10n_th_account_tax: fix copy multi records

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -514,7 +514,6 @@ class AccountMove(models.Model):
         For case reverse move,
         Tax number and date must have value from wizard reversal.
         """
-        self.ensure_one()
         new = super().copy(default)
         tax_number = self.env.context.get("tax_invoice_number")
         tax_date = self.env.context.get("tax_invoice_date")


### PR DESCRIPTION
Step to reproduce:
1. create 2 vendor bills
2. Go to list view > select all > action > duplicate

Because version18 supported multi copy.