### PR TITLE
[15.0][FIX] l10n_th_account_tax: guard _prepare_withholding_move and preapare_wht_certs against missing wht_tax_id

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -506,14 +506,20 @@ class AccountMove(models.Model):
         if wht_move.move_id.move_type == "in_refund":
             amount_income = -abs(wht_move.balance)
             amount_wht = 0.0
-        return {
+        vals = {
             "partner_id": wht_move.partner_id.id,
             "amount_income": amount_income,
             "amount_wht": amount_wht,
-            "wht_tax_id": wht_move.wht_tax_id.id,
-            "wht_cert_income_type": wht_move.wht_tax_id.wht_cert_income_type,
             "company_id": wht_move.company_id.id,
         }
+        if wht_move.wht_tax_id:
+            vals.update(
+                {
+                    "wht_tax_id": wht_move.wht_tax_id.id,
+                    "wht_cert_income_type": wht_move.wht_tax_id.wht_cert_income_type,
+                }
+            )
+        return vals
 
     def _get_tax_invoice_number(self, move, tax_invoice, tax):
         """Tax Invoice Numbering for Customer Invioce / Receipt
@@ -627,6 +633,9 @@ class AccountMove(models.Model):
                 filter(lambda l: l["partner_id"][0] == partner.id, wht_move_groups)
             )
             for wht_move in wht_moves:
+                wht_tax_id = (
+                    wht_move["wht_tax_id"] and wht_move["wht_tax_id"][0] or False
+                )
                 cert_line_vals.append(
                     (
                         0,
@@ -636,11 +645,12 @@ class AccountMove(models.Model):
                             "wht_cert_income_desc": wht_move["wht_cert_income_desc"],
                             "base": wht_move["amount_income"],
                             "amount": wht_move["amount_wht"],
-                            "wht_tax_id": wht_move["wht_tax_id"][0],
+                            "wht_tax_id": wht_tax_id,
                         },
                     )
                 )
-                wht_tax_set.add(wht_move["wht_tax_id"][0])
+                if wht_tax_id:
+                    wht_tax_set.add(wht_tax_id)
             cert_vals = {
                 "move_id": self.id,
                 "payment_id": self.payment_id.id,


### PR DESCRIPTION
Fix TypeError: 'bool' object is not subscriptable when creating a WHT Certificate without a WHT tax specified in the Journal Item.

**Prerequisites:**
- มี WHT account (`account.account` ที่มี `wht_account = True`) อย่างน้อย 1 บัญชี
- มี `account.withholding.tax` อย่างน้อย 1 รายการ

### Steps to Reproduce

1. **สร้าง Vendor Bill**
   - `Invoices > Vendors > Create`
   - Vendor: เลือก vendor ใดก็ได้
   - Product line: เลือก product ที่ **ไม่ได้ตั้งค่า WHT** (ทั้ง `wht_tax_id`, `supplier_wht_tax_id`, `supplier_company_wht_tax_id` เป็น `False`)
   - Confirm

2. **Register Payment**
   - คลิก `Register Payment`
   - ใน wizard ตั้งค่า:
     - `Amount` = ยอดเต็ม
     - `Difference Handling` = **Keep Open** (ไม่ reconcile)
   - คลิก `Create Payment`

3. **เพิ่ม Journal Item แบบ Manual ที่ Payment JE**
   - เปิด Payment journal entry ที่เพิ่งสร้าง
   - คลิก `Journal Items` tab
   - คลิก `Add a line`
   - ตั้งค่า:
     - `Account` = เลือกบัญชีที่ mark เป็น `wht_account = True`
     - `Debit/Credit` = ยอด WHT ที่ต้องการ (เช่น 30)
     - `Partner` = vendor คนเดิม
     - **อย่า**กรอก `WHT` field (`wht_tax_id`)
     - `Label` = "Manual WHT"

4. **Post the Payment**
   - คลิก `Post`

### Expected Result (ก่อน Fix)

`AttributeError: 'bool' object has no attribute 'id'`

Traceback จะชี้มาที่ `account_move.py:513` ใน `_prepare_withholding_move()`

### Expected Result (หลัง Fix)

Post ผ่าน สร้าง `account.withholding.move` โดยมี:
- `amount_income` = base amount
- `amount_wht` = WHT amount
- `wht_tax_id` = **ว่าง**
- `wht_cert_income_type` = **ว่าง**

จากนั้น user สามารถไปที่ **Withholding Moves** tab ของ JE เพื่อเลือก `wht_cert_income_type` เอง แล้วกดสร้าง WHT Cert ได้