### PR TITLE
[18.0][FIX] l10n_th_account_tax_report: change name to doc name

### DIFF
--- a/l10n_th_account_tax_report/reports/tax_report.py
+++ b/l10n_th_account_tax_report/reports/tax_report.py
@@ -20,6 +20,7 @@ class ThaiTaxReport(models.AbstractModel):
             company_id, account_id, partner_id, tax_invoice_number,
             TO_CHAR(tax_date, 'DD/MM/YYYY') AS tax_date,
             string_agg(DISTINCT name, ', ' ORDER BY name) AS name,
+            string_agg(DISTINCT move_name, ', ' ORDER BY move_name) AS move_name,
             sum(tax_base_amount) tax_base_amount,
             sum(tax_amount) tax_amount
         """
@@ -43,7 +44,8 @@ class ThaiTaxReport(models.AbstractModel):
             CASE WHEN m.ref IS NOT NULL
                 THEN m.ref
             ELSE ml.move_name
-            END AS name
+            END AS name,
+            ml.move_name AS move_name
         """
 
     def _query_groupby_tax(self):

--- a/l10n_th_account_tax_report/reports/tax_report_xlsx.py
+++ b/l10n_th_account_tax_report/reports/tax_report_xlsx.py
@@ -21,39 +21,39 @@ class ReportThaiTaxXlsx(models.TransientModel):
 
     def _get_tax_template(self):
         return {
-            "1_index": {
+            "01_index": {
                 "header": {"value": "#"},
                 "data": {"value": self._render("index")},
                 "width": 3,
             },
-            "2_tax_date": {
+            "02_tax_date": {
                 "header": {"value": "Date"},
                 "data": {
                     "value": self._render("tax_date"),
                 },
                 "width": 12,
             },
-            "3_tax_invoice": {
+            "03_tax_invoice": {
                 "header": {"value": "Number"},
                 "data": {"value": self._render("tax_invoice_number")},
                 "width": 18,
             },
-            "4_partner_name": {
+            "04_partner_name": {
                 "header": {"value": "Cust./Sup."},
                 "data": {"value": self._render("partner_name")},
                 "width": 30,
             },
-            "5_partner_vat": {
+            "05_partner_vat": {
                 "header": {"value": "Tax ID"},
                 "data": {"value": self._render("partner_vat")},
                 "width": 15,
             },
-            "6_partner_branch": {
+            "06_partner_branch": {
                 "header": {"value": "Branch ID"},
                 "data": {"value": self._render("partner_branch")},
                 "width": 12,
             },
-            "7_tax_base_amount": {
+            "07_tax_base_amount": {
                 "header": {"value": "Base Amount"},
                 "data": {
                     "value": self._render("tax_base_amount"),
@@ -61,7 +61,7 @@ class ReportThaiTaxXlsx(models.TransientModel):
                 },
                 "width": 21,
             },
-            "8_tax_amount": {
+            "08_tax_amount": {
                 "header": {"value": "Tax Amount"},
                 "data": {
                     "value": self._render("tax_amount"),
@@ -69,9 +69,14 @@ class ReportThaiTaxXlsx(models.TransientModel):
                 },
                 "width": 21,
             },
-            "9_doc_ref": {
+            "09_doc_ref": {
                 "header": {"value": "Doc Ref."},
                 "data": {"value": self._render("doc_ref")},
+                "width": 18,
+            },
+            "10_doc_number": {
+                "header": {"value": "Doc Number"},
+                "data": {"value": self._render("doc_number")},
                 "width": 18,
             },
         }
@@ -114,6 +119,7 @@ class ReportThaiTaxXlsx(models.TransientModel):
             "tax_base_amount": line["tax_base_amount"] or 0.00,
             "tax_amount": line["tax_amount"] or 0.00,
             "doc_ref": line["name"] or "",
+            "doc_number": line["move_name"] or "",
         }
 
     def _write_ws_lines(self, row_pos, ws, ws_params, tax_report_data):
@@ -137,7 +143,7 @@ class ReportThaiTaxXlsx(models.TransientModel):
         return row_pos
 
     def _write_ws_footer(self, row_pos, ws, ws_params, res_data):
-        col_end = ws_params["wanted_list"].index("7_tax_base_amount")
+        col_end = ws_params["wanted_list"].index("07_tax_base_amount")
         ws.merge_range(row_pos, 0, row_pos, col_end - 1, "")
         ws.write_row(
             row_pos, 0, ["Total Balance"], FORMATS["format_theader_blue_right"]
@@ -148,6 +154,7 @@ class ReportThaiTaxXlsx(models.TransientModel):
             [
                 res_data["total_base"],
                 res_data["total_tax"],
+                "",
                 "",
             ],
             FORMATS["format_theader_blue_amount_right"],

--- a/l10n_th_account_tax_report/reports/templates/tax_report.xml
+++ b/l10n_th_account_tax_report/reports/templates/tax_report.xml
@@ -102,6 +102,7 @@
                 <div class="act_as_cell">Base Amount</div>
                 <div class="act_as_cell">Tax Amount</div>
                 <div class="act_as_cell">Doc Ref.</div>
+                <div class="act_as_cell">Doc Number</div>
             </div>
         </div>
     </template>
@@ -135,6 +136,9 @@
             <div class="act_as_cell">
                 <t t-out="line['name']" />
             </div>
+            <div class="act_as_cell">
+                <t t-out="line['move_name']" />
+            </div>
         </div>
     </template>
 
@@ -152,6 +156,7 @@
             <div class="act_as_cell amount">
                 <t t-out="'{0:,.2f}'.format(total_tax)" />
             </div>
+            <div class="act_as_cell" />
             <div class="act_as_cell" />
         </div>
     </template>

--- a/l10n_th_account_tax_report/reports/templates/tax_report_rd.xml
+++ b/l10n_th_account_tax_report/reports/templates/tax_report_rd.xml
@@ -242,7 +242,7 @@
                                             <span t-out="line['tax_invoice_number']" />
                                         </td>
                                         <td class="text-center">
-                                            <t t-out="line['name']" />
+                                            <t t-out="line['move_name']" />
                                         </td>
                                         <td>
                                             <span t-out="line['partner_name']" />


### PR DESCRIPTION
This PR fixed Thai tax report
- HTML, PDF, Excel (without RD Prep) add doc number
<img width="5504" height="776" alt="Screenshot 2026-06-30 194458" src="https://github.com/user-attachments/assets/2004d803-dd7f-466e-aeba-6dbc07b4605a" />
- HTML, PDF (with PD Prep) add doc number
<img width="5498" height="1058" alt="Screenshot 2026-06-30 200108" src="https://github.com/user-attachments/assets/2cd32830-5abd-4940-a014-b6257518dbeb" />
