### PR TITLE
[18.0][IMP] l10n_th_account_tax_expense: use journal following clearing journal and support tax reconcile

### DIFF
--- a/l10n_th_account_tax_expense/models/account_move.py
+++ b/l10n_th_account_tax_expense/models/account_move.py
@@ -1,7 +1,7 @@
 # Copyright 2020 Ecosoft Co., Ltd (http://ecosoft.co.th/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
-from odoo import _, models
+from odoo import models
 from odoo.exceptions import UserError
 
 
@@ -104,7 +104,7 @@ class AccountMove(models.Model):
         )
         if sheets:
             raise UserError(
-                _(
+                self.env._(
                     "Unable to cancel this journal entry. You must first cancel "
                     "the related withholding tax (Journal Voucher)."
                 )

--- a/l10n_th_account_tax_expense/models/hr_expense_sheet.py
+++ b/l10n_th_account_tax_expense/models/hr_expense_sheet.py
@@ -1,7 +1,7 @@
 # Copyright 2021 Ecosoft Co., Ltd (http://ecosoft.co.th/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
-from odoo import Command, _, fields, models
+from odoo import Command, fields, models
 from odoo.exceptions import UserError
 
 
@@ -43,7 +43,9 @@ class HrExpenseSheet(models.Model):
             for tax_invoice in purchase_tax_invoices:
                 expense = tax_invoice.move_line_id.expense_id
                 if not (expense.tax_number and expense.tax_date):
-                    raise UserError(_("Please fill in tax invoice and tax date"))
+                    raise UserError(
+                        self.env._("Please fill in tax invoice and tax date")
+                    )
             sheet.account_move_ids._sync_expense_tax_invoice()
         return super().action_sheet_move_post()
 
@@ -54,9 +56,11 @@ class HrExpenseSheet(models.Model):
         sheet.ensure_one()
         # Validation
         if sheet.state not in ("done", "post"):
-            raise UserError(_("Only posted or paid expense report can create JV"))
+            raise UserError(
+                self.env._("Only posted or paid expense report can create JV")
+            )
         if sheet.wht_move_id and sheet.wht_move_id.state != "cancel":
-            raise UserError(_("Already created withholding tax JV"))
+            raise UserError(self.env._("Already created withholding tax JV"))
         # Window action
         xmlid = "account.action_move_journal_line"
         action = self.env["ir.actions.act_window"]._for_xml_id(xmlid)
@@ -100,7 +104,11 @@ class HrExpenseSheet(models.Model):
         # Dr. Reconcilable Account (i.e., AP, Advance)
         # amount goes to AP first, then the rest go to Advance
         av_account = self.advance_sheet_id.expense_line_ids.mapped("account_id")
-        ap_accounts = move_lines.mapped("account_id").filtered(
+        # Exclude tax lines from AP candidates (e.g., reconcilable Tax Paid).
+        ap_move_lines = move_lines.filtered(
+            lambda line: not line.tax_line_id and not line.tax_repartition_line_id
+        )
+        ap_accounts = ap_move_lines.mapped("account_id").filtered(
             lambda account, av_account=av_account: account.reconcile
             and account != av_account
         )
@@ -128,6 +136,7 @@ class HrExpenseSheet(models.Model):
         # Create JV
         move_vals = {
             "move_type": "entry",
+            "journal_id": self.clearing_journal_id.id,
             "ref": self.account_move_ids.display_name,
             "line_ids": [Command.create(line_vals) for line_vals in line_vals_list],
         }

--- a/l10n_th_account_tax_expense/tests/test_expense_withholding_tax.py
+++ b/l10n_th_account_tax_expense/tests/test_expense_withholding_tax.py
@@ -51,6 +51,18 @@ class TestHrExpenseWithholdingTax(TestExpenseCommon):
 
         cls.emp_advance = cls.env.ref("hr_expense_advance_clearing.product_emp_advance")
         cls.emp_advance.property_account_expense_id = cls.advance_account
+
+        # Configure the journal required to create advance clearing moves and WHT JVs
+        cls.clearing_journal = cls.env["account.journal"].create(
+            {
+                "name": "WHT Clearing",
+                "code": "WHTC",
+                "type": "general",
+                "company_id": cls.company_data["company"].id,
+            }
+        )
+        cls.company_data["company"].clearing_journal_id = cls.clearing_journal
+
         # Create expense 1,000
         cls.expense_sheet = cls.create_expense_report(
             cls,
@@ -165,6 +177,42 @@ class TestHrExpenseWithholdingTax(TestExpenseCommon):
                             "wht_tax_id": cls.wht_1.id,
                             "bill_partner_id": cls.partner1.id,
                             "tax_ids": False,
+                        }
+                    )
+                ],
+            },
+        )
+
+        # Purchase tax whose tax (Tax Paid) account is configured as
+        # reconcilable - this is what used to make the WHT entry pick the
+        # tax line up as an AP candidate, producing an extra 0/0 line.
+        cls.tax_purchase_reconcile = cls.tax_purchase_a.copy(
+            {"name": "test: tax purchase (reconcilable)"}
+        )
+        cls.tax_purchase_reconcile.invoice_repartition_line_ids.filtered(
+            lambda line: line.repartition_type == "tax"
+        ).account_id.reconcile = True
+        # Create clearing expense with tax + WHT (clearing < advance)
+        cls.clearing_less_tax = cls.create_expense_report(
+            cls,
+            {
+                "name": "Buy service 800 (tax + WHT)",
+                "expense_line_ids": [
+                    Command.create(
+                        {
+                            "name": "Clearing 800 (tax + WHT)",
+                            "employee_id": cls.expense_employee.id,
+                            "product_id": cls.product_travel.id,
+                            "quantity": 1,
+                            "payment_mode": "own_account",
+                            "company_id": cls.company_data["company"].id,
+                            "date": "2021-10-11",
+                            "total_amount_currency": 800.00,
+                            "wht_tax_id": cls.wht_1.id,
+                            "bill_partner_id": cls.partner1.id,
+                            "tax_number": "TAXINV-005",
+                            "tax_date": "2021-10-11",
+                            "tax_ids": [Command.set(cls.tax_purchase_reconcile.ids)],
                         }
                     )
                 ],
@@ -335,3 +383,31 @@ class TestHrExpenseWithholdingTax(TestExpenseCommon):
         move = self.clearing_less.account_move_ids
         move.button_cancel()
         self.assertEqual(move.state, "cancel")
+
+    def test_05_clearing_tax_reconcile_wht(self):
+        """WHT entry must not hold an extra 0/0 tax line when the clearing
+        uses a tax whose tax account is reconcilable (regression test)."""
+        # ------------------ Advance --------------------------
+        self.advance.action_submit_sheet()
+        self.advance.action_approve_expense_sheets()
+        self.advance.action_sheet_move_post()
+        payment_wizard = self._register_payment(self.advance.account_move_ids)
+        payment_wizard.action_create_payments()
+        self.assertEqual(self.advance.state, "done")
+        # ------------------ Clearing --------------------------
+        # Clear this with previous advance
+        self.clearing_less_tax.advance_sheet_id = self.advance
+        self.clearing_less_tax.action_submit_sheet()
+        self.clearing_less_tax.action_approve_expense_sheets()
+        self.clearing_less_tax.action_sheet_move_post()
+        # clearing < advance, it will change state to done
+        self.assertEqual(self.clearing_less_tax.state, "done")
+        # Create withholding tax entry
+        self.clearing_less_tax.action_create_withholding_tax_entry()
+        wht_move = self.clearing_less_tax.wht_move_id
+        self.assertTrue(wht_move)
+        # The JV must only hold the WHT Cr. line and the Advance Dr. line
+        self.assertEqual(len(wht_move.line_ids), 2)
+        accounts = wht_move.line_ids.account_id
+        self.assertIn(self.wht_account, accounts)
+        self.assertIn(self.advance_account, accounts)


### PR DESCRIPTION
This PR fixes 2 case
1. Create WHT Move following Clearing Journal from https://github.com/OCA/hr-expense/pull/375
2. If Tax is reconcile when create WHT, it will create line Tax with 0
<img width="1624" height="722" alt="selection_475" src="https://github.com/user-attachments/assets/9541c004-a981-4621-ad42-409fee586556" />


Note: This PR will merge when https://github.com/OCA/hr-expense/pull/375 is merged