### PR TITLE
[15.0][FIX] l10n_th_account_tax: check state before create mirror wht move

### DIFF
--- a/l10n_th_account_tax/models/account_move.py
+++ b/l10n_th_account_tax/models/account_move.py
@@ -563,6 +563,8 @@ class AccountMove(models.Model):
     def button_cancel(self):
         res = super().button_cancel()
         for rec in self:
+            if rec.state != "cancel":
+                continue
             # Create the mirror only for those posted
             for line in rec.wht_move_ids:
                 line.copy(


### PR DESCRIPTION
## Cause

When the `account_move_cancel_confirm` module is installed, clicking **Cancel** on a payment triggers the creation of the mirror WHT journal entry even though the cancellation has not yet been confirmed. At this point, the payment is still not in the **cancelled** state because the confirmation wizard is being displayed.

## Fix

Add a state check so that the mirror WHT journal entry is created **only after the payment has actually been cancelled** (i.e., when the state is `cancel`).

## Steps to Reproduce

1. Install the `account_move_cancel_confirm` module.
2. Create a payment with WHT.
3. Click **Cancel**.
4. The confirmation popup is displayed.
5. Click **Cancel** on the popup or simply close it.

## Current Behavior

The system creates the mirror WHT journal entry even though the payment cancellation has not been confirmed.

## Expected Behavior

The mirror WHT journal entry should only be created after the payment has been successfully cancelled.
