### PR TITLE
[18.0][IMP] l10n_th_account_tax: reverse credit note taxes

### DIFF
--- a/l10n_th_account_tax/models/account_tax.py
+++ b/l10n_th_account_tax/models/account_tax.py
@@ -3,6 +3,7 @@
 
 
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 
 
 class AccountTax(models.Model):
@@ -14,6 +15,37 @@ class AccountTax(models.Model):
         help="Optional sequence as Tax Invoice number",
         copy=False,
     )
+    reverse_tax_id = fields.Many2one(
+        comodel_name="account.tax",
+        string="Reverse Tax (Credit Note)",
+        domain="[('type_tax_use', '=', type_tax_use), "
+        "('tax_exigibility', '=', 'on_invoice'), "
+        "('company_id', '=', company_id)]",
+        check_company=True,
+        help="Replacement tax for credit notes when the original invoice is paid.",
+    )
+
+    @api.constrains("reverse_tax_id")
+    def _check_reverse_tax_id(self):
+        for tax in self:
+            reverse_tax = tax.reverse_tax_id
+            if not reverse_tax:
+                continue
+            if tax.tax_exigibility != "on_payment":
+                raise ValidationError(
+                    self.env._(
+                        "Reverse Tax can only be set on a cash basis (undue) tax."
+                    )
+                )
+            if reverse_tax.tax_exigibility != "on_invoice":
+                raise ValidationError(
+                    self.env._("Reverse Tax must be a due ('on invoice') tax.")
+                )
+            if reverse_tax.type_tax_use != tax.type_tax_use:
+                raise ValidationError(
+                    self.env._("Reverse Tax must have the same Tax Scope.")
+                )
+
     sequence_number_next = fields.Integer(
         string="Next Number",
         help="The next sequence number will be used for the next tax invoice.",

--- a/l10n_th_account_tax/tests/__init__.py
+++ b/l10n_th_account_tax/tests/__init__.py
@@ -1,5 +1,6 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
 from . import test_tax_invoice
+from . import test_reverse_taxes
 from . import test_withholding_tax
 from . import test_withholding_tax_pit

--- a/l10n_th_account_tax/tests/test_reverse_taxes.py
+++ b/l10n_th_account_tax/tests/test_reverse_taxes.py
@@ -1,0 +1,80 @@
+# Copyright 2024 Ecosoft Co., Ltd (https://ecosoft.co.th/)
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
+
+from odoo.tests import tagged
+
+from .test_tax_invoice import TestTaxInvoice
+
+
+@tagged("post_install", "-at_install")
+class TestReverseTaxes(TestTaxInvoice):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.output_vat.refund_repartition_line_ids.filtered(
+            lambda rep: rep.repartition_type == "tax"
+        ).account_id = cls.output_vat_acct
+        cls.undue_output_vat.reverse_tax_id = cls.output_vat
+
+    def _register_payment(self, invoice, amount=None):
+        action = invoice.action_register_payment()
+        ctx = action.get("context")
+        vals = {"journal_id": self.journal_bank.id}
+        if amount is not None:
+            vals["amount"] = amount
+        wizard = self.env["account.payment.register"].with_context(**ctx).create(vals)
+        wizard.action_create_payments()
+        return invoice
+
+    def _new_reversal(self, invoice):
+        return (
+            self.env["account.move.reversal"]
+            .with_context(active_model="account.move", active_ids=invoice.ids)
+            .create({"journal_id": invoice.journal_id.id})
+        )
+
+    def _tax_by_account(self, move):
+        result = {}
+        for line in move.line_ids.filtered("tax_line_id"):
+            result.setdefault(line.account_id, 0.0)
+            result[line.account_id] += abs(line.balance)
+        return result
+
+    def test_01_credit_note_full_paid_uses_due_tax(self):
+        """Fully paid invoice -> credit note books VAT to due account."""
+        invoice = self.customer_invoice_undue_vat
+        invoice.action_post()
+        self._register_payment(invoice)
+        self.assertIn(invoice.payment_state, ("paid", "in_payment"))
+
+        wizard = self._new_reversal(invoice)
+        self.assertTrue(wizard.show_reverse_taxes)
+        self.assertTrue(wizard.use_reverse_taxes)
+        wizard.reverse_moves()
+        refund = wizard.new_move_ids
+        refund.action_post()
+
+        tax_by_account = self._tax_by_account(refund)
+        # All 7.0 VAT on the due account, nothing on the undue/suspense account
+        self.assertEqual(tax_by_account.get(self.output_vat_acct), 7.0)
+        self.assertNotIn(self.undue_output_vat_acct, tax_by_account)
+        self.assertEqual(sum(refund.invoice_line_ids.mapped("price_subtotal")), 100.0)
+
+    def test_03_no_mapping_keeps_undue(self):
+        """Without reverse_tax_id, behaviour is unchanged (undue account)."""
+        self.undue_output_vat.reverse_tax_id = False
+        invoice = self.customer_invoice_undue_vat
+        invoice.action_post()
+        self._register_payment(invoice)
+
+        wizard = self._new_reversal(invoice)
+        self.assertFalse(wizard.show_reverse_taxes)
+        self.assertFalse(wizard.use_reverse_taxes)
+        wizard.reverse_moves()
+        refund = wizard.new_move_ids
+        refund.action_post()
+
+        tax_by_account = self._tax_by_account(refund)
+        # VAT stays on the undue/suspense account
+        self.assertEqual(tax_by_account.get(self.undue_output_vat_acct), 7.0)
+        self.assertNotIn(self.output_vat_acct, tax_by_account)

--- a/l10n_th_account_tax/views/account_tax_view.xml
+++ b/l10n_th_account_tax/views/account_tax_view.xml
@@ -16,6 +16,15 @@
                     invisible="type_tax_use != 'sale' or not taxinv_sequence_id"
                 />
             </xpath>
+            <xpath
+                expr="//field[@name='cash_basis_transition_account_id']"
+                position="after"
+            >
+                <field
+                    name="reverse_tax_id"
+                    invisible="tax_exigibility != 'on_payment'"
+                />
+            </xpath>
         </field>
     </record>
 </odoo>

--- a/l10n_th_account_tax/wizard/account_move_reversal.py
+++ b/l10n_th_account_tax/wizard/account_move_reversal.py
@@ -1,7 +1,7 @@
 # Copyright 2023 Ecosoft Co., Ltd (https://ecosoft.co.th/)
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html)
 
-from odoo import fields, models
+from odoo import Command, api, fields, models
 
 
 class AccountMoveReversal(models.TransientModel):
@@ -9,6 +9,34 @@ class AccountMoveReversal(models.TransientModel):
 
     tax_invoice_number = fields.Char(copy=False)
     tax_invoice_date = fields.Date(copy=False)
+    show_reverse_taxes = fields.Boolean(compute="_compute_show_reverse_taxes")
+    use_reverse_taxes = fields.Boolean(
+        string="Reverse Tax",
+        compute="_compute_use_reverse_taxes",
+        store=True,
+        readonly=False,
+        help="For a fully paid invoice, book the credit note VAT to the due tax "
+        "account (e.g. Output VAT) instead of the undue/suspense account.",
+    )
+
+    def _is_reverse_taxes_eligible(self):
+        self.ensure_one()
+        moves = self.move_ids
+        return (
+            bool(moves)
+            and all(move.payment_state in ("paid", "in_payment") for move in moves)
+            and bool(moves.invoice_line_ids.tax_ids.filtered("reverse_tax_id"))
+        )
+
+    @api.depends("move_ids")
+    def _compute_show_reverse_taxes(self):
+        for wiz in self:
+            wiz.show_reverse_taxes = wiz._is_reverse_taxes_eligible()
+
+    @api.depends("move_ids")
+    def _compute_use_reverse_taxes(self):
+        for wiz in self:
+            wiz.use_reverse_taxes = wiz._is_reverse_taxes_eligible()
 
     def reverse_moves(self, is_modify=False):
         self.ensure_one()
@@ -17,4 +45,39 @@ class AccountMoveReversal(models.TransientModel):
                 tax_invoice_number=self.tax_invoice_number,
                 tax_invoice_date=self.tax_invoice_date,
             )
-        return super().reverse_moves(is_modify)
+        action = super().reverse_moves(is_modify)
+        if self.use_reverse_taxes and self.show_reverse_taxes:
+            self._apply_reverse_taxes(self.new_move_ids)
+        return action
+
+    def _swapped_taxes(self, taxes):
+        """Replace each undue tax by its reverse (due) tax, keep the rest."""
+        result = self.env["account.tax"]
+        for tax in taxes:
+            result |= tax.reverse_tax_id or tax
+        return result
+
+    def _apply_reverse_taxes(self, moves):
+        for move in moves.filtered(
+            lambda m: m.state == "draft"
+            and m.move_type in ("out_refund", "in_refund")
+            and m.reversed_entry_id
+        ):
+            # Collect all line changes and apply them in a single move.write so
+            # account.move._sync_dynamic_lines recomputes the tax lines.
+            commands = []
+            for line in move.invoice_line_ids:
+                if not line.tax_ids.filtered("reverse_tax_id"):
+                    continue
+                commands.append(
+                    Command.update(
+                        line.id,
+                        {
+                            "tax_ids": [
+                                Command.set(self._swapped_taxes(line.tax_ids).ids)
+                            ]
+                        },
+                    )
+                )
+            if commands:
+                move.write({"invoice_line_ids": commands})

--- a/l10n_th_account_tax/wizard/account_move_reversal_view.xml
+++ b/l10n_th_account_tax/wizard/account_move_reversal_view.xml
@@ -11,6 +11,8 @@
                     invisible="move_type != 'in_invoice'"
                 />
                 <field name="tax_invoice_date" invisible="move_type != 'in_invoice'" />
+                <field name="show_reverse_taxes" invisible="1" />
+                <field name="use_reverse_taxes" invisible="not show_reverse_taxes" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
## Summary

### Problem

Credit Notes created from fully paid invoices using Undue VAT (Cash Basis) still use the original Undue Tax, causing VAT to be posted back to the suspense account instead of reducing Due VAT.

### Solution

Add support for swapping Undue Tax to Due Tax on Credit Notes for fully paid invoices. The mapping is configured through reverse_tax_id on the tax, and can be enabled from the reversal wizard.

### Changes
- Add `reverse_tax_id` to `account.tax` for mapping Undue Tax to Due Tax.
- Add Reverse Tax configuration to the tax form.
<img width="1280" height="678" alt="SCR-20260716-lyyo" src="https://github.com/user-attachments/assets/cfc022f7-cec3-430c-8da7-44a695359091" />

- Add a **Reverse Tax** option to the Credit Note reversal wizard.
<img width="1280" height="322" alt="image" src="https://github.com/user-attachments/assets/7ee5f5c8-ed24-43bb-ba99-6a51ef2f95ce" />

- Automatically swap taxes and recompute tax lines after creating the Credit Note.

 Invoice
<img width="1280" height="581" alt="SCR-20260716-lzrh" src="https://github.com/user-attachments/assets/ec09df6a-ca1a-40d8-aaf6-9d1c4f109210" />

Credit note
<img width="1280" height="631" alt="SCR-20260716-lzll" src="https://github.com/user-attachments/assets/41ca019d-13ed-4776-9e6e-27e87a82c802" />
<img width="1280" height="679" alt="SCR-20260716-lzhy" src="https://github.com/user-attachments/assets/4b9fcaaa-d337-4ac2-baff-d543e3832750" />

