### PR TITLE
[15.0][FIX] l10n_th_bank_payment_export: BOT account number must be 10 digits

### DIFF
--- a/l10n_th_bank_payment_export/models/bank_payment_export_line.py
+++ b/l10n_th_bank_payment_export/models/bank_payment_export_line.py
@@ -148,6 +148,13 @@ class BankPaymentExportLine(models.Model):
         if not acc_number:
             return "**receiver account number is null**"
         sanitize_acc_number = sanitize_account_number(acc_number)
+        # BOT: ธนาคารแห่งประเทศไทย (must be 10 digits)
+        if partner_bank_id.bank_id.bic == "BOTHTHBK":
+            return (
+                len(sanitize_acc_number) <= 10
+                and sanitize_acc_number.zfill(10)
+                or "**Digit account number is not correct**"
+            )
         if len(sanitize_acc_number) <= 11:
             return sanitize_acc_number.zfill(11)
         # BAAC: ธ. เพื่อการเกษตรและสหกรณ์การเกษตร

--- a/l10n_th_bank_payment_export/tests/test_bank_payment_export.py
+++ b/l10n_th_bank_payment_export/tests/test_bank_payment_export.py
@@ -289,6 +289,15 @@ class TestBankPaymentExport(CommonBankPaymentExport):
                 result = line._get_acc_number_digit(line.payment_partner_bank_id)
                 self.assertEqual(len(result), 11)
 
+                # BOTHTHBK must be 10 digits
+                line.payment_partner_bank_id.bank_id.bic = "BOTHTHBK"
+                line.payment_partner_bank_id.acc_number = "123456789"
+                result = line._get_acc_number_digit(line.payment_partner_bank_id)
+                self.assertEqual(result, "0123456789")
+                line.payment_partner_bank_id.acc_number = "12345678901"
+                result = line._get_acc_number_digit(line.payment_partner_bank_id)
+                self.assertEqual(result, "**Digit account number is not correct**")
+
                 # GSBATHBK 12 digits -> 11 digits (2 - 12)
                 line.payment_partner_bank_id.bank_id.bic = "GSBATHBK"
                 line.payment_partner_bank_id.acc_number = "123456789012"


### PR DESCRIPTION
Receiver account for Bank of Thailand (BIC BOTHTHBK) was padded to 11 digits like other banks, but BOT requires exactly 10 digits. Return zfill(10) for accounts up to 10 digits and an error string for longer ones.